### PR TITLE
security: disable debug mode, add .dockerignore, hide server list

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Git
+.git/
+.github/
+
+# Environment and secrets
+.env
+.env.*
+.envprod.yaml
+.envstage.yaml
+
+# Local credentials
+local_auth/
+credentials.json
+oauth.keys.json
+
+# IDE
+.vscode/
+.cursor/
+.idea/
+
+# Development
+scratch/
+tests/
+*.log
+__pycache__/
+*.py[cod]
+.pytest_cache/
+
+# Documentation
+*.md
+!README.md

--- a/src/servers/remote.py
+++ b/src/servers/remote.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import uvicorn
 import argparse
 import importlib.util
@@ -13,6 +14,9 @@ from starlette.applications import Starlette
 from starlette.responses import JSONResponse, Response
 from starlette.types import Receive, Scope, Send
 from prometheus_client import Counter, Gauge, generate_latest, CONTENT_TYPE_LATEST
+
+# Production mode: set DEBUG=true in environment to enable debug mode
+DEBUG_MODE = os.environ.get("DEBUG", "false").lower() == "true"
 
 from mcp.server.lowlevel import Server
 from mcp.server import streamable_http_manager
@@ -111,7 +115,7 @@ def create_metrics_app():
     routes = [Route("/metrics", endpoint=metrics_endpoint)]
 
     app = Starlette(
-        debug=True,
+        debug=DEBUG_MODE,
         routes=routes,
     )
 
@@ -214,15 +218,15 @@ def create_starlette_app():
 
         logger.info(f"Added stateless routes for server: {server_name}")
 
-    # Health checks
+    # Health checks — do not expose server list in unauthenticated endpoints
     async def root_handler(request):
         """Root endpoint that returns a simple 200 OK response"""
         return JSONResponse(
             {
                 "status": "ok",
-                "message": "guMCP stateless server running",
-                "servers": list(servers.keys()),
+                "message": "pfMCP server running",
                 "mode": "stateless",
+                "server_count": len(servers),
             }
         )
 
@@ -231,7 +235,7 @@ def create_starlette_app():
     async def health_check(request):
         """Health check endpoint"""
         return JSONResponse(
-            {"status": "ok", "servers": list(servers.keys()), "mode": "stateless"}
+            {"status": "ok", "mode": "stateless", "server_count": len(servers)}
         )
 
     routes.append(Route("/health_check", endpoint=health_check))
@@ -246,7 +250,7 @@ def create_starlette_app():
             logger.info("Application shutting down...")
 
     app = Starlette(
-        debug=True,
+        debug=DEBUG_MODE,
         routes=routes,
         lifespan=lifespan,
     )


### PR DESCRIPTION
## Summary

Quick security hardening fixes identified during the pfMCP security review. These are low-risk, high-impact changes that can be deployed immediately.

## Changes

### 1. Disable debug mode in production (`remote.py`)
- `debug=True` was hardcoded on both the main app and metrics app Starlette instances
- This caused full Python stack traces (with file paths, library versions, variable values) to be returned in HTTP error responses
- Now controlled via `DEBUG` environment variable (defaults to `false`)
- **No env change needed** — production `.envprod.yaml` doesn't set `DEBUG`, so it defaults to off

### 2. Add `.dockerignore`
- The Dockerfile uses `COPY . .` with no `.dockerignore`, copying the entire repo into the container image
- This could include `.env` files, `.git/` history, `local_auth/` credential directories, and IDE configs
- New `.dockerignore` excludes: `.env*`, `.git/`, `local_auth/`, `credentials.json`, IDE dirs, tests, and logs

### 3. Remove server list from health endpoints (`remote.py`)
- Both `/` and `/health_check` returned `"servers": ["slack", "gmail", "salesforce", ...]` — the full list of 70+ integration names
- This aids reconnaissance by revealing exactly which integrations are available
- Now returns only `"server_count": N` instead of the full list

## Test plan

- [ ] Verify `/` returns `{"status": "ok", "mode": "stateless", "server_count": N}` without server names
- [ ] Verify `/health_check` returns same format
- [ ] Verify invalid routes return generic error (not stack trace) when `DEBUG` is unset
- [ ] Verify `DEBUG=true` restores stack traces for local development
- [ ] Verify Docker image builds correctly with `.dockerignore` (no missing files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)