### PR TITLE
feat(gmail,outlook): return threadId/conversationId in read_emails

### DIFF
--- a/src/servers/gmail/main.py
+++ b/src/servers/gmail/main.py
@@ -591,8 +591,11 @@ def create_server(user_id, api_key=None):
                 is_unread = "UNREAD" in labels
 
                 # Build email summary
+                thread_id = msg.get("threadId", "")
+
                 email_summary = (
                     f"ID: {message['id']}\n"
+                    f"Thread ID: {thread_id}\n"
                     f"From: {sender}\n"
                     f"Subject: {subject}\n"
                     f"Date: {date}\n"

--- a/src/servers/outlook/main.py
+++ b/src/servers/outlook/main.py
@@ -399,7 +399,7 @@ def create_server(user_id, api_key=None):
 
                 # Build request parameters
                 params = {
-                    "$select": "id,subject,from,toRecipients,ccRecipients,receivedDateTime,bodyPreview,hasAttachments",
+                    "$select": "id,subject,from,toRecipients,ccRecipients,receivedDateTime,bodyPreview,hasAttachments,conversationId",
                     "$top": count,
                     "$orderby": "receivedDateTime desc",
                 }
@@ -525,6 +525,7 @@ def create_server(user_id, api_key=None):
 
                     email_info = {
                         "id": email.get("id"),
+                        "conversationId": email.get("conversationId", ""),
                         "subject": subject,
                         "from": {"name": from_name, "email": from_email},
                         "to": to_recipients,


### PR DESCRIPTION
## Summary
- **Gmail `read_emails`**: now includes `Thread ID: <threadId>` in each email's text output, extracted from the Gmail API message response
- **Outlook `read_emails`**: now includes `conversationId` in each email's JSON response object, fetched via the Graph API `$select` parameter

These IDs allow downstream consumers (e.g. `GmailIncomingTriggerNode`, `OutlookIncomingTriggerNode`) to correlate incoming emails with conversation threads.

## Test plan
- [ ] Call Gmail `read_emails` tool and verify each email block contains a `Thread ID:` line
- [ ] Call Outlook `read_emails` tool and verify each email object in the JSON response contains a `conversationId` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)