### PR TITLE
chore: use ubicloud-standard-2 as GitHub Actions runner

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   format-check:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy_cloud_function:
     name: Deploy Cloud Function
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubicloud-standard-2
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy_cloud_function:
     name: Deploy Cloud Function
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubicloud-standard-2
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1


### PR DESCRIPTION
## Summary
- Replace `ubuntu-latest` and `buildjet-2vcpu-ubuntu-2204` with `ubicloud-standard-2` across all workflow files (format-check, stage, production)
- Ubicloud runners provide cost savings and comparable performance

## Test plan
- [ ] Verify format-check workflow runs successfully on `ubicloud-standard-2`
- [ ] Verify stage deploy workflow runs successfully
- [ ] Verify production deploy workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)