### PR TITLE
feat: add diagnostic logging for HubSpot tool API responses

### DIFF
--- a/src/servers/hubspot/main.py
+++ b/src/servers/hubspot/main.py
@@ -2255,12 +2255,17 @@ def create_server(user_id, api_key=None):
 
             # Process the response
             status_code = response.status_code
+            logger.info(f"Tool {name}: HubSpot API responded with status {status_code}")
 
             try:
                 response_data = response.json()
                 response_data["_status_code"] = status_code
             except:
                 response_data = {"_status_code": status_code, "result": response.text}
+
+            # Log result count for list-style tools
+            if isinstance(response_data.get("results"), list):
+                logger.info(f"Tool {name}: returned {len(response_data['results'])} results")
 
             if 200 <= status_code < 300:
                 return [


### PR DESCRIPTION
## Summary
- Add logging of HubSpot API response status code after each tool call
- Add result count logging for list-style tools (e.g., `list_owners`, `list_pipelines`)

## Context
Companion to workflow-builder PR #1177 — investigating `Resolved 0 options for key "owners"`. These logs will reveal whether the HubSpot API is returning errors or empty results when `list_owners` is called.

## Test plan
- [ ] Deploy and call `list_owners` — verify logs show `Tool list_owners: HubSpot API responded with status 200` and `Tool list_owners: returned N results`
- [ ] If API returns error status, logs will show the error code for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)