### PR TITLE
feat(peakflo): add custom field support to invoice create/update tools

### DIFF
--- a/src/servers/peakflo/schemas/common.py
+++ b/src/servers/peakflo/schemas/common.py
@@ -108,6 +108,24 @@ bank_detail_schema = {
     "additionalProperties": True,
 }
 
+custom_field_schema = {
+    "type": "array",
+    "description": "Array of custom fields",
+    "items": {
+        "type": "object",
+        "properties": {
+            "customFieldNumber": {
+                "type": "string",
+                "description": "Custom field identifier (references a custom field definition configured in Peakflo)",
+            },
+            "value": {
+                "description": "Value of the custom field (can be string, number, date string in DD-MM-YYYY format, or array of strings for multi-select)",
+            },
+        },
+        "required": ["customFieldNumber", "value"],
+    },
+}
+
 line_item_schema = {
     "type": "array",
     "description": "Array of line items for the invoice",
@@ -146,6 +164,7 @@ line_item_schema = {
                 "type": "string",
                 "description": "Item reference identifier",
             },
+            "customField": custom_field_schema,
         },
         "required": ["description", "unitAmount", "quantity"],
     },

--- a/src/servers/peakflo/schemas/invoice.py
+++ b/src/servers/peakflo/schemas/invoice.py
@@ -1,4 +1,4 @@
-from peakflo.schemas.common import line_item_schema
+from peakflo.schemas.common import custom_field_schema, line_item_schema
 
 create_invoice_schema = {
     "type": "object",
@@ -59,6 +59,7 @@ create_invoice_schema = {
             "type": "string",
             "description": "Invoice number identifier",
         },
+        "customField": custom_field_schema,
     },
     "required": [
         "externalId",
@@ -137,6 +138,7 @@ update_invoice_schema = {
             "type": "string",
             "description": "Invoice number identifier",
         },
+        "customField": custom_field_schema,
     },
     "required": [
         "externalId",

--- a/src/servers/peakflo/schemas/vendor.py
+++ b/src/servers/peakflo/schemas/vendor.py
@@ -2,6 +2,7 @@ from peakflo.schemas.common import (
     contact_schema,
     address_schema,
     bank_detail_schema,
+    custom_field_schema,
 )
 
 create_vendor_schema = {
@@ -71,22 +72,7 @@ create_vendor_schema = {
             "type": "boolean",
             "description": "Whether VAT is applicable",
         },
-        "customField": {
-            "type": "array",
-            "description": "Array of custom fields",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "customFieldNumber": {
-                        "type": "string",
-                        "description": "Custom field identifier",
-                    },
-                    "value": {
-                        "description": "Value of the custom field (can be string, number, date, or array for multi-select)",
-                    },
-                },
-            },
-        },
+        "customField": custom_field_schema,
     },
 }
 


### PR DESCRIPTION
## Summary
- Add `customField` parameter to `create_invoice` and `update_invoice` MCP tool schemas for both header-level and line-level custom fields
- Extract shared `custom_field_schema` in `common.py` with `customFieldNumber` (required) + `value` (required) — matching the Peakflo API contract
- Add `customField` to `line_item_schema` so line items can also carry custom fields
- Refactor `vendor.py` to reuse the shared schema instead of inline definition

### Related PR
- API changes: https://github.com/peakflo/api/pull/618

## Test plan
- [x] Python schema imports and assertions pass
- [x] No changes needed in `main.py` — arguments pass through to the API as-is
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)