### PR TITLE
Update peakflo_api.py

### DIFF
--- a/src/servers/peakflo/tools/peakflo_api.py
+++ b/src/servers/peakflo/tools/peakflo_api.py
@@ -1,5 +1,5 @@
 from mcp.types import Tool
-from servers.peakflo.schemas.vendor import read_vendor_output, create_vendor_schema
+from servers.peakflo.schemas.vendor import create_vendor_schema
 from servers.peakflo.schemas.utility import (
     soa_email_input_schema,
     create_task_input_schema,
@@ -31,7 +31,6 @@ vendor_tools = [
             },
             "required": ["externalId", "tenantId"],
         },
-        outputSchema=read_vendor_output,
     ),
     Tool(
         name="create_vendor",


### PR DESCRIPTION
Removed outputSchema from read_vendor to fix MCP output validation errors. handle_call_tool returns plain TextContent for all tools and does not support structured MCP output. read_vendor was the only tool declaring outputSchema, causing a mismatch with actual responses. MCP expected structured output but received plain text, triggering validation failure. This change aligns the tool definition with existing server behavior.