### PR TITLE
feat(slack-user): add link to 20x in transparency footer

### DIFF
--- a/src/servers/slack-user/main.py
+++ b/src/servers/slack-user/main.py
@@ -35,7 +35,7 @@ SERVICE_NAME = Path(__file__).parent.name
 # Footer appended to all outgoing messages for transparency.
 # Since messages are posted as the authenticated user (no bot badge),
 # this footer makes it clear the message was sent by an AI agent.
-SENT_FROM_FOOTER = "\n\n_Sent from 20x_"
+SENT_FROM_FOOTER = "\n\n_Sent from <https://peakflo.co/20x-agent-orchestrator|20x>_"
 
 # User-level OAuth scopes required for posting as the user.
 # These are requested as user_scopes in the Nango OAuth flow (xoxp- token).
@@ -1147,7 +1147,10 @@ def process_blocks(blocks, title):
         {
             "type": "context",
             "elements": [
-                {"type": "mrkdwn", "text": "_Sent from 20x_"},
+                {
+                    "type": "mrkdwn",
+                    "text": "_Sent from <https://peakflo.co/20x-agent-orchestrator|20x>_",
+                },
             ],
         }
     )


### PR DESCRIPTION
## Summary
Added a link to https://peakflo.co/20x-agent-orchestrator in the "Sent from 20x" footer for the `slack-user` integration. This affects both plain text messages and block kit messages.

## Changes
- Updated `SENT_FROM_FOOTER` in `src/servers/slack-user/main.py`
- Updated `process_blocks` in `src/servers/slack-user/main.py`
- Updated `README.md` and `config.yaml` to reflect the change
- Updated test descriptions in `tests/servers/slack-user/tests.py`

## Test plan
- Verified that the link format follows Slack's mrkdwn syntax: `<URL|Text>`
- Changes are straightforward string updates in the transparency footer logic

Generated with [Claude Code](https://claude.com)