### PR TITLE
feat: add status to read_vendor_output schema

### DIFF
--- a/src/servers/peakflo/schemas/vendor.py
+++ b/src/servers/peakflo/schemas/vendor.py
@@ -160,5 +160,10 @@ read_vendor_output = {
             "type": "boolean",
             "description": "Whether VAT is applicable",
         },
+        "status": {
+            "type": "string",
+            "description": "Current status of the vendor (active, archived, or deleted)",
+            "enum": ["active", "archived", "deleted"],
+        },
     },
 }


### PR DESCRIPTION
## Summary

Add `status` field to `read_vendor_output` schema with enum values: `active`, `archived`, `deleted`.

Documentation-only change — runtime behavior is unaffected since the raw API response is passed through regardless of outputSchema.

## Changes
- `src/servers/peakflo/schemas/vendor.py` — added `status` to `read_vendor_output`