### PR TITLE
chore: set min-instances=0 for staging Cloud Run deployment

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -46,4 +46,4 @@ jobs:
 
       - name: Deploy to GCP
         run: |
-          gcloud run deploy pf-mcp --source . --env-vars-file .envstage.yaml --region=us-central1 --memory=1Gi --no-allow-unauthenticated
+          gcloud run deploy pf-mcp --source . --env-vars-file .envstage.yaml --region=us-central1 --memory=1Gi --min-instances=0 --no-allow-unauthenticated


### PR DESCRIPTION
## Summary
- Explicitly adds `--min-instances=0` to the staging Cloud Run deploy command in `.github/workflows/stage.yml`
- This flag was present in the original Cloud Functions deployment but was lost during the migration to Cloud Run
- Ensures the staging service can scale to zero when idle, reducing costs

## Test plan
- [ ] Merge to `main` and verify the staging deployment workflow runs successfully
- [ ] Verify the Cloud Run service `pf-mcp` in staging shows `minInstances: 0` via `gcloud run services describe pf-mcp --region=us-central1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)