### PR TITLE
fix(peakflo): remove env-var hard check on send_message

### DIFF
--- a/src/servers/peakflo/main.py
+++ b/src/servers/peakflo/main.py
@@ -161,15 +161,11 @@ async def make_peakflo_request(name, arguments, token):
         url = f"{PEAKFLO_V1_BASE_URL}/upload-soa-email"
         message = "SOA email sent successfully"
     elif name == "send_message":
-        if not gateway_key:
-            raise ValueError(
-                "PEAKFLO_API_GATEWAY_KEY is required to send messages through the rate-limited gateway"
-            )
-        # MCP exposes invoiceExternalId as agent-friendly
-        # sugar; the API contract uses objectType + objectExternalId and
-        # rejects unknown keys (allowUnknown:false). Translate before
-        # forwarding. Other fields (recipients/cc/bcc as RecipientSpec,
-        # messageBody, subject, …) map 1:1 to the API contract.
+        # MCP exposes invoiceExternalId as agent-friendly sugar; the API
+        # contract uses objectType + objectExternalId and rejects unknown
+        # keys (allowUnknown:false). Translate before forwarding. Other
+        # fields (recipients/cc/bcc as RecipientSpec, messageBody, subject,
+        # …) map 1:1 to the API contract.
         invoice_external_id = arguments.pop("invoiceExternalId", None)
         if invoice_external_id:
             arguments["objectType"] = "invoice"


### PR DESCRIPTION
## Summary
- Drops the \`if not gateway_key: raise ValueError(...)\` guard inside the \`send_message\` branch of \`make_peakflo_request\`.
- The check fires in cloud (where \`PEAKFLO_API_GATEWAY_KEY\` is never set) and short-circuits every \`send_message\` call with \"GATEWAY_KEY is required to send messages through the rate-limited gateway\" — before any HTTP request is even attempted.
- The check was originally added as a response to an Iqbal review on rate-limiting, but the cloud path doesn't use that env var. Auth on cloud is via the Nango bearer token (now the native API key after #161). The Peakflo API also accepts \`x-api-key\` + \`x-client-id\` for external callers (Settings → Integrations → API), which is independent of this MCP layer.
- The conditional header-attachment one block above is left intact so local-dev that does set the env var still works.

## Test plan
- [x] Python parses (\`ast.parse\`).
- [ ] Retest \`send_message\` against \`0demoConnectId\` peakflo connection after deploy — expect a 200 instead of the hard-error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)