### PR TITLE
feat(peakflo): support peakflo-api-key provider config

### DIFF
--- a/src/auth/constants.py
+++ b/src/auth/constants.py
@@ -28,6 +28,10 @@ SERVICE_NAME_MAP = {
         "nango_service_name": "peakflo",
         "auth_type": AUTH_TYPE_API_KEY,
     },
+    "peakflo-api-key": {
+        "nango_service_name": "peakflo-api-key",
+        "auth_type": AUTH_TYPE_API_KEY,
+    },
     "netsuite": {
         "nango_service_name": "netsuite-tba",
         "auth_type": AUTH_TYPE_TBA,

--- a/src/servers/peakflo/main.py
+++ b/src/servers/peakflo/main.py
@@ -54,6 +54,12 @@ async def get_peakflo_credentials(user_id, api_key=None):
     """
     Get Peakflo credentials, supporting both new and legacy auth flows.
 
+    Tries two Nango provider config keys in order:
+      1. "peakflo" — legacy connections (unauthenticated/metadata-based) and
+         connections created via the original integration type.
+      2. "peakflo-api-key" — new connections created via the native API_KEY
+         integration type in Nango.
+
     New flow (API_KEY): Nango stores the API key natively.
         NangoAuthClient returns {apiKey: "pk_xxx"} → we use apiKey directly.
 
@@ -62,16 +68,27 @@ async def get_peakflo_credentials(user_id, api_key=None):
         generates a JWT internally, returning {access_token: "jwt_xxx", expires_at: ...}.
     """
     auth_client = create_auth_client(api_key=api_key)
-    # Use async version to avoid blocking the event loop.
-    # Sync requests.get() + time.sleep() in the non-async version would block
-    # all concurrent SSE streams on this pf-mcp instance, causing Cloud Run
-    # to truncate responses and workflow-api to hang indefinitely.
-    if hasattr(auth_client, "async_get_user_credentials"):
-        credentials_data = await auth_client.async_get_user_credentials(
-            "peakflo", user_id
-        )
-    else:
-        credentials_data = auth_client.get_user_credentials("peakflo", user_id)
+    # Try both Nango provider config keys: legacy "peakflo" first, then
+    # "peakflo-api-key" for connections created via the new integration type.
+    # NangoAuthClient caches successful lookups, so subsequent calls are fast.
+    credentials_data = None
+    for service_name in ["peakflo", "peakflo-api-key"]:
+        # Use async version to avoid blocking the event loop.
+        # Sync requests.get() + time.sleep() in the non-async version would block
+        # all concurrent SSE streams on this pf-mcp instance, causing Cloud Run
+        # to truncate responses and workflow-api to hang indefinitely.
+        if hasattr(auth_client, "async_get_user_credentials"):
+            credentials_data = await auth_client.async_get_user_credentials(
+                service_name, user_id
+            )
+        else:
+            credentials_data = auth_client.get_user_credentials(service_name, user_id)
+
+        if credentials_data:
+            logger.info(
+                f"[get_peakflo_credentials] resolved credentials via '{service_name}' for {user_id}"
+            )
+            break
 
     if not credentials_data:
         error_str = f"Peakflo API key not found for user {user_id}."


### PR DESCRIPTION
## Summary
- Adds `peakflo-api-key` entry to `SERVICE_NAME_MAP` with `AUTH_TYPE_API_KEY`
- Updates `get_peakflo_credentials` to try both Nango provider config keys (`peakflo` first, then `peakflo-api-key`) for backward compatibility
- Credential resolution is cached after first success, so no performance impact on subsequent tool calls

## Test plan
- [ ] Verify existing connections (under `peakflo` provider) continue to resolve credentials
- [ ] Verify new connections (under `peakflo-api-key` provider) resolve credentials via fallback
- [ ] Companion PR: peakflo/workflow-builder (peakflo-api-key integration type registration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)