### PR TITLE
feat(peakflo): add get_tenant tool

### DIFF
--- a/src/servers/peakflo/main.py
+++ b/src/servers/peakflo/main.py
@@ -232,6 +232,10 @@ async def make_peakflo_request(name, arguments, token):
             f"/actions/{action_external_id}"
         )
         message = "Collection workflow action updated successfully"
+    elif name == "get_tenant":
+        method = "GET"
+        url = f"{PEAKFLO_V1_BASE_URL}/tenant"
+        message = "Tenant information fetched successfully"
     else:
         raise ValueError(f"Unknown tool call: {name}")
 

--- a/src/servers/peakflo/tools/peakflo_api.py
+++ b/src/servers/peakflo/tools/peakflo_api.py
@@ -139,4 +139,15 @@ utility_tools = [
         ),
         inputSchema=update_collection_workflow_action_input_schema,
     ),
+    Tool(
+        name="get_tenant",
+        description=(
+            "Get the current tenant information for the authenticated API key. "
+            "Returns tenantId, companyName, and other tenant profile data."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {},
+        },
+    ),
 ]


### PR DESCRIPTION
## Summary
- Adds a `get_tenant` MCP tool to the peakflo server that calls `GET /v1/tenant` to return the authenticated tenant's ID and company name
- This tool enables workflow-builder's webhook handler to resolve the Peakflo tenant ID through pfMCP instead of calling the Peakflo API directly

## Test plan
- [ ] Verify `get_tenant` tool appears in `list_tools` response
- [ ] Call `get_tenant` with a valid Peakflo API key connection and verify it returns `tenantId`
- [ ] Call with invalid credentials and verify proper error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)