### PR TITLE
Add create / delete / get-action / delete-workflow MCP tools

### DIFF
--- a/src/servers/peakflo/README.md
+++ b/src/servers/peakflo/README.md
@@ -33,6 +33,10 @@ python src/servers/peakflo/main.py auth
 | **run_bill_po_matching** | Run Purchase Order (PO) matching on an existing bill. Updates line-level PO links and 3-way matching details. Use when re-running matching after a bill was created without POs or when POs/bill data changed. Tenant is taken from the auth token; provide at least one of `billId`, `externalId`, or `sourceId` to identify the bill. |
 | **update_collection_workflow** | Update top-level fields on a collection workflow (dunning cadence) — title, default template, reply-to, etc. Partial update; only supplied fields are written. Routes through `PUT /v1/collection-workflows/:externalId`. |
 | **update_collection_workflow_action** | Update a single step inside a collection workflow — channel, message body, trigger timing, enabled flag. Routes through `PUT /v1/collection-workflows/:externalId/actions/:actionExternalId`. |
+| **create_collection_workflow_action** | Append a new step (cadence action) to an existing collection workflow — e.g. add a −3-day pre-due nudge or a Day-3 overdue email. `actionExternalId` is caller-assigned and must be unique within the workflow. Routes through `POST /v1/collection-workflows/:externalId/actions`. |
+| **delete_collection_workflow** | Delete a workflow template and every action under it. Customers assigned to this workflow stop receiving its cadence. Routes through `DELETE /v1/collection-workflows/:externalId`. |
+| **get_collection_workflow_action** | Read one step of a workflow. The parent `get_collection_workflow` already returns nested actions; use this when you already know the `actionExternalId` (e.g. to verify a PATCH landed). Routes through `GET /v1/collection-workflows/:externalId/actions/:actionExternalId`. |
+| **delete_collection_workflow_action** | Delete one step from a workflow's cadence. The rest keeps firing. Routes through `DELETE /v1/collection-workflows/:externalId/actions/:actionExternalId`. |
 
 ### Run
 

--- a/src/servers/peakflo/config.yaml
+++ b/src/servers/peakflo/config.yaml
@@ -52,3 +52,15 @@ tools:
   - name: "update_collection_workflow_action"
     description: "Update a single step (action) inside a collection workflow"
     required_scopes: []
+  - name: "create_collection_workflow_action"
+    description: "Append a new step (action) to a collection workflow"
+    required_scopes: []
+  - name: "delete_collection_workflow"
+    description: "Delete a collection workflow template and all its actions"
+    required_scopes: []
+  - name: "get_collection_workflow_action"
+    description: "Read one step (action) of a collection workflow"
+    required_scopes: []
+  - name: "delete_collection_workflow_action"
+    description: "Delete one step (action) from a collection workflow"
+    required_scopes: []

--- a/src/servers/peakflo/main.py
+++ b/src/servers/peakflo/main.py
@@ -232,6 +232,40 @@ async def make_peakflo_request(name, arguments, token):
             f"/actions/{action_external_id}"
         )
         message = "Collection workflow action updated successfully"
+    elif name == "create_collection_workflow_action":
+        # Append a new action. actionExternalId stays in the body — it's
+        # not used for URL routing on POST, only for downstream addressing
+        # when subsequent update_collection_workflow_action calls reference
+        # it.
+        external_id = arguments.pop("externalId")
+        method = "POST"
+        url = (
+            f"{PEAKFLO_V1_BASE_URL}/collection-workflows/{external_id}/actions"
+        )
+        message = "Collection workflow action created successfully"
+    elif name == "delete_collection_workflow":
+        external_id = arguments.pop("externalId")
+        method = "DELETE"
+        url = f"{PEAKFLO_V1_BASE_URL}/collection-workflows/{external_id}"
+        message = "Collection workflow deleted successfully"
+    elif name == "get_collection_workflow_action":
+        external_id = arguments.pop("externalId")
+        action_external_id = arguments.pop("actionExternalId")
+        method = "GET"
+        url = (
+            f"{PEAKFLO_V1_BASE_URL}/collection-workflows/{external_id}"
+            f"/actions/{action_external_id}"
+        )
+        message = "Collection workflow action fetched successfully"
+    elif name == "delete_collection_workflow_action":
+        external_id = arguments.pop("externalId")
+        action_external_id = arguments.pop("actionExternalId")
+        method = "DELETE"
+        url = (
+            f"{PEAKFLO_V1_BASE_URL}/collection-workflows/{external_id}"
+            f"/actions/{action_external_id}"
+        )
+        message = "Collection workflow action deleted successfully"
     else:
         raise ValueError(f"Unknown tool call: {name}")
 

--- a/src/servers/peakflo/main.py
+++ b/src/servers/peakflo/main.py
@@ -239,9 +239,7 @@ async def make_peakflo_request(name, arguments, token):
         # it.
         external_id = arguments.pop("externalId")
         method = "POST"
-        url = (
-            f"{PEAKFLO_V1_BASE_URL}/collection-workflows/{external_id}/actions"
-        )
+        url = f"{PEAKFLO_V1_BASE_URL}/collection-workflows/{external_id}/actions"
         message = "Collection workflow action created successfully"
     elif name == "delete_collection_workflow":
         external_id = arguments.pop("externalId")

--- a/src/servers/peakflo/schemas/utility.py
+++ b/src/servers/peakflo/schemas/utility.py
@@ -594,37 +594,35 @@ create_collection_workflow_action_input_schema = {
                 "with 409."
             ),
         },
-        "actionName": update_collection_workflow_action_input_schema[
-            "properties"
-        ]["actionName"],
-        "actionType": update_collection_workflow_action_input_schema[
-            "properties"
-        ]["actionType"],
-        "triggerType": update_collection_workflow_action_input_schema[
-            "properties"
-        ]["triggerType"],
+        "actionName": update_collection_workflow_action_input_schema["properties"][
+            "actionName"
+        ],
+        "actionType": update_collection_workflow_action_input_schema["properties"][
+            "actionType"
+        ],
+        "triggerType": update_collection_workflow_action_input_schema["properties"][
+            "triggerType"
+        ],
         "triggerTimePeriod": update_collection_workflow_action_input_schema[
             "properties"
         ]["triggerTimePeriod"],
         "triggerTimePeriodUntil": update_collection_workflow_action_input_schema[
             "properties"
         ]["triggerTimePeriodUntil"],
-        "subject": update_collection_workflow_action_input_schema[
-            "properties"
-        ]["subject"],
-        "messageBody": update_collection_workflow_action_input_schema[
-            "properties"
-        ]["messageBody"],
-        "paymentLink": update_collection_workflow_action_input_schema[
-            "properties"
-        ]["paymentLink"],
-        "recipients": update_collection_workflow_action_input_schema[
-            "properties"
-        ]["recipients"],
-        "cc": update_collection_workflow_action_input_schema["properties"]["cc"],
-        "bcc": update_collection_workflow_action_input_schema["properties"][
-            "bcc"
+        "subject": update_collection_workflow_action_input_schema["properties"][
+            "subject"
         ],
+        "messageBody": update_collection_workflow_action_input_schema["properties"][
+            "messageBody"
+        ],
+        "paymentLink": update_collection_workflow_action_input_schema["properties"][
+            "paymentLink"
+        ],
+        "recipients": update_collection_workflow_action_input_schema["properties"][
+            "recipients"
+        ],
+        "cc": update_collection_workflow_action_input_schema["properties"]["cc"],
+        "bcc": update_collection_workflow_action_input_schema["properties"]["bcc"],
     },
     "required": [
         "externalId",

--- a/src/servers/peakflo/schemas/utility.py
+++ b/src/servers/peakflo/schemas/utility.py
@@ -572,6 +572,71 @@ update_collection_workflow_action_input_schema = {
 }
 
 
+# create_collection_workflow_action — append a new step to an existing
+# cadence. Backs POST /v1/collection-workflows/:externalId/actions.
+# Same payload shape as the update schema, but the cadence triplet
+# (actionExternalId / actionName / actionType / triggerType /
+# triggerTimePeriod) is required so the new step is fully addressable
+# and schedulable from the moment it lands.
+create_collection_workflow_action_input_schema = {
+    "type": "object",
+    "properties": {
+        "externalId": {
+            "type": "string",
+            "description": "External ID of the parent workflow.",
+        },
+        "actionExternalId": {
+            "type": "string",
+            "description": (
+                "Caller-assigned external ID for the new step. Reuse the same "
+                "value on subsequent update_collection_workflow_action calls. "
+                "Must be unique within the workflow — duplicates are rejected "
+                "with 409."
+            ),
+        },
+        "actionName": update_collection_workflow_action_input_schema[
+            "properties"
+        ]["actionName"],
+        "actionType": update_collection_workflow_action_input_schema[
+            "properties"
+        ]["actionType"],
+        "triggerType": update_collection_workflow_action_input_schema[
+            "properties"
+        ]["triggerType"],
+        "triggerTimePeriod": update_collection_workflow_action_input_schema[
+            "properties"
+        ]["triggerTimePeriod"],
+        "triggerTimePeriodUntil": update_collection_workflow_action_input_schema[
+            "properties"
+        ]["triggerTimePeriodUntil"],
+        "subject": update_collection_workflow_action_input_schema[
+            "properties"
+        ]["subject"],
+        "messageBody": update_collection_workflow_action_input_schema[
+            "properties"
+        ]["messageBody"],
+        "paymentLink": update_collection_workflow_action_input_schema[
+            "properties"
+        ]["paymentLink"],
+        "recipients": update_collection_workflow_action_input_schema[
+            "properties"
+        ]["recipients"],
+        "cc": update_collection_workflow_action_input_schema["properties"]["cc"],
+        "bcc": update_collection_workflow_action_input_schema["properties"][
+            "bcc"
+        ],
+    },
+    "required": [
+        "externalId",
+        "actionExternalId",
+        "actionName",
+        "actionType",
+        "triggerType",
+        "triggerTimePeriod",
+    ],
+}
+
+
 list_collection_workflows_input_schema = {
     "type": "object",
     "properties": {
@@ -593,4 +658,55 @@ get_collection_workflow_input_schema = {
         },
     },
     "required": ["externalId"],
+}
+
+
+delete_collection_workflow_input_schema = {
+    "type": "object",
+    "properties": {
+        "externalId": {
+            "type": "string",
+            "description": (
+                "External ID of the workflow to delete. Removes the template "
+                "and every action under it; customers assigned to this "
+                "workflow stop receiving its cadence."
+            ),
+        },
+    },
+    "required": ["externalId"],
+}
+
+
+get_collection_workflow_action_input_schema = {
+    "type": "object",
+    "properties": {
+        "externalId": {
+            "type": "string",
+            "description": "External ID of the parent workflow.",
+        },
+        "actionExternalId": {
+            "type": "string",
+            "description": "External ID of the action step to read.",
+        },
+    },
+    "required": ["externalId", "actionExternalId"],
+}
+
+
+delete_collection_workflow_action_input_schema = {
+    "type": "object",
+    "properties": {
+        "externalId": {
+            "type": "string",
+            "description": "External ID of the parent workflow.",
+        },
+        "actionExternalId": {
+            "type": "string",
+            "description": (
+                "External ID of the action step to delete. The rest of the "
+                "cadence keeps firing — only this step is removed."
+            ),
+        },
+    },
+    "required": ["externalId", "actionExternalId"],
 }

--- a/src/servers/peakflo/tools/peakflo_api.py
+++ b/src/servers/peakflo/tools/peakflo_api.py
@@ -6,6 +6,10 @@ from servers.peakflo.schemas.utility import (
     create_task_input_schema,
     add_action_log_input_schema,
     run_bill_po_matching_input_schema,
+    create_collection_workflow_action_input_schema,
+    delete_collection_workflow_input_schema,
+    delete_collection_workflow_action_input_schema,
+    get_collection_workflow_action_input_schema,
     update_collection_workflow_input_schema,
     update_collection_workflow_action_input_schema,
     list_collection_workflows_input_schema,
@@ -138,5 +142,43 @@ utility_tools = [
             "copy on a specific step."
         ),
         inputSchema=update_collection_workflow_action_input_schema,
+    ),
+    Tool(
+        name="create_collection_workflow_action",
+        description=(
+            "Append a new step (cadence action) to an existing collection "
+            "workflow. Used to add reminders the template is missing — e.g. "
+            "a −3-day pre-due nudge or a Day-3 overdue email — without "
+            "rewriting the whole cadence. actionExternalId is caller-assigned "
+            "and must be unique within the workflow."
+        ),
+        inputSchema=create_collection_workflow_action_input_schema,
+    ),
+    Tool(
+        name="delete_collection_workflow",
+        description=(
+            "Delete a collection workflow template and every action under "
+            "it. Customers assigned to this workflow stop receiving its "
+            "cadence."
+        ),
+        inputSchema=delete_collection_workflow_input_schema,
+    ),
+    Tool(
+        name="get_collection_workflow_action",
+        description=(
+            "Read one step (action) of a collection workflow. The parent "
+            "get_collection_workflow already returns nested actions; use "
+            "this when you already know the actionExternalId (e.g. to "
+            "verify a PATCH landed)."
+        ),
+        inputSchema=get_collection_workflow_action_input_schema,
+    ),
+    Tool(
+        name="delete_collection_workflow_action",
+        description=(
+            "Delete one step (action) from a collection workflow. The rest "
+            "of the cadence keeps firing — only this step is removed."
+        ),
+        inputSchema=delete_collection_workflow_action_input_schema,
     ),
 ]


### PR DESCRIPTION
## Summary

Wraps the four new peakflo-api endpoints (peakflo/api#677) as MCP tools so the AR Workflow Recommender can apply its "create" suggestions end-to-end:

- `create_collection_workflow_action` → POST `/v1/collection-workflows/:externalId/actions`
- `get_collection_workflow_action` → GET `/v1/collection-workflows/:externalId/actions/:actionExternalId`
- `delete_collection_workflow_action` → DELETE `/v1/collection-workflows/:externalId/actions/:actionExternalId`
- `delete_collection_workflow` → DELETE `/v1/collection-workflows/:externalId`

`create_collection_workflow_action_input_schema` reuses every field definition from `update_collection_workflow_action_input_schema` by reference, so the action-type / trigger-type / payment-link enums stay in sync with one source of truth. Required keys are caller-assigned `actionExternalId` + the cadence triplet (actionName / actionType / triggerType / triggerTimePeriod) so the new step is fully addressable and schedulable from the moment it lands.

`config.yaml` + README updated.

## Test plan
- [ ] After api#677 deploys to stage, list tools on the peakflo MCP server → 4 new tools appear.
- [ ] Call `create_collection_workflow_action` against `vendor-general-wf` → 201 + new step shows up.
- [ ] Same call twice → second returns 409.
- [ ] `delete_collection_workflow_action` on the newly-created step → 204 and it's gone.
- [ ] `get_collection_workflow_action` on a missing actionExternalId → 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)