### PR TITLE
Fix merge bug: peakflo MCP server fails to boot (SyntaxError)

### DIFF
--- a/src/servers/peakflo/tools/peakflo_api.py
+++ b/src/servers/peakflo/tools/peakflo_api.py
@@ -180,6 +180,8 @@ utility_tools = [
             "of the cadence keeps firing — only this step is removed."
         ),
         inputSchema=delete_collection_workflow_action_input_schema,
+    ),
+    Tool(
         name="get_tenant",
         description=(
             "Get the current tenant information for the authenticated API key. "


### PR DESCRIPTION
## Summary

The merge between #166 (`get_tenant` tool) and #167 (collection-workflow CRUD) collapsed both `Tool()` entries into a single call with the `name=` keyword specified twice. Python raises `SyntaxError: keyword argument repeated: name` at module import, so the peakflo MCP server now fails to boot — every `integration_mcp_tool_call` against a peakflo-api-key integration returns HTTP 404, including pre-existing tools like `send_message` and `list_collection_workflows`.

Splits them back into two separate `Tool()` entries.

## Test plan
- [ ] After merge + deploy, `integration_mcp_tool_call` with `list_collection_workflows` against the VendorID peakflo-api-key integration returns 200 (not 404).
- [ ] `get_tenant` tool is still callable.
- [ ] All four new CRUD tools (`create_collection_workflow_action` / `get_collection_workflow_action` / `delete_collection_workflow_action` / `delete_collection_workflow`) show up in `integration_mcp_tools_list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)