### PR TITLE
[TSK-16649] Add Peakflo credential broker client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ GCS_BUCKET_NAME=your-bucket-name  # gcs provider only
 # Delivery tracking (optional — watch/webhook only set up when defined)
 GMAIL_PUBSUB_TOPIC=projects/your-project/topics/gmail-notifications
 OUTLOOK_WEBHOOK_URL=https://your-domain.com/api/outlook/webhook
+
+# Peakflo internal credential broker for direct system-of-record tools.
+# Store the real secret in Secret Manager for deployed environments.
+PEAKFLO_INTERNAL_API_BASE_URL=https://api.peakflo.ai
+PF_MCP_CREDENTIAL_BROKER_SECRET=...

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           echo "ANTHROPIC_API_KEY: ${{ secrets.PROD_ANTHROPIC_API_KEY }}" >> .envprod.yaml
           echo "NANGO_SECRET_KEY: ${{ secrets.PROD_NANGO_SECRET_KEY }}" >> .envprod.yaml
+          echo "PF_MCP_CREDENTIAL_BROKER_SECRET: ${{ secrets.PROD_PF_MCP_CREDENTIAL_BROKER_SECRET }}" >> .envprod.yaml
           echo "NANGO_HOST: ${{ vars.PROD_NANGO_HOST || 'https://api.nango.dev' }}" >> .envprod.yaml
           echo 'PEAKFLO_API_BASE_URL: "https://api.peakflo.co/v1"' >> .envprod.yaml
           echo "GCS_BUCKET_NAME: ${{ vars.PROD_GCS_BUCKET_NAME }}" >> .envprod.yaml

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           echo "ANTHROPIC_API_KEY: ${{ secrets.INT_ANTHROPIC_API_KEY }}" >> .envstage.yaml
           echo "NANGO_SECRET_KEY: ${{ secrets.INT_NANGO_SECRET_KEY }}" >> .envstage.yaml
+          echo "PF_MCP_CREDENTIAL_BROKER_SECRET: ${{ secrets.INT_PF_MCP_CREDENTIAL_BROKER_SECRET }}" >> .envstage.yaml
           echo "NANGO_HOST: ${{ vars.INT_NANGO_HOST || 'https://api.nango.dev' }}" >> .envstage.yaml
           echo 'PEAKFLO_API_BASE_URL: "https://stage-api.peakflo.co/v1"' >> .envstage.yaml
           echo "GCS_BUCKET_NAME: ${{ vars.INT_GCS_BUCKET_NAME }}" >> .envstage.yaml

--- a/src/servers/peakflo/credential_broker.py
+++ b/src/servers/peakflo/credential_broker.py
@@ -1,0 +1,84 @@
+import os
+import logging
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger("peakflo-credential-broker")
+
+
+class PeakfloCredentialBrokerClient:
+    """
+    Client for Peakflo's internal system-of-record credential broker.
+
+    This is intentionally separate from normal Peakflo public API auth. It uses a
+    service-to-service secret and must never expose returned credentials as MCP
+    tool output.
+    """
+
+    def __init__(
+        self,
+        api_base_url: Optional[str] = None,
+        broker_secret: Optional[str] = None,
+    ):
+        self.api_base_url = (
+            api_base_url
+            or os.environ.get("PEAKFLO_INTERNAL_API_BASE_URL")
+            or os.environ.get("PEAKFLO_API_BASE_URL", "").replace("/v1", "")
+        ).rstrip("/")
+        self.broker_secret = broker_secret or os.environ.get(
+            "PF_MCP_CREDENTIAL_BROKER_SECRET"
+        )
+
+        if not self.api_base_url:
+            raise ValueError(
+                "PEAKFLO_INTERNAL_API_BASE_URL or PEAKFLO_API_BASE_URL is required"
+            )
+        if not self.broker_secret:
+            raise ValueError("PF_MCP_CREDENTIAL_BROKER_SECRET is required")
+
+    async def resolve_system_of_record_credentials(
+        self,
+        tenant_id: str,
+        source_system: str,
+        purpose: str = "workflow",
+    ) -> Dict[str, Any]:
+        """
+        Resolve short-lived credentials for a tenant's connected system of record.
+
+        The Peakflo API owns refresh-token storage and refresh. pfMCP receives
+        only what it needs to call the provider API directly.
+        """
+        url = f"{self.api_base_url}/internal/credentials/system-of-record/resolve"
+        payload = {
+            "tenantId": tenant_id,
+            "sourceSystem": source_system,
+            "purpose": purpose,
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                url,
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {self.broker_secret}",
+                    "Content-Type": "application/json",
+                },
+                timeout=10.0,
+            )
+
+        if response.status_code < 200 or response.status_code >= 300:
+            logger.warning(
+                "[PeakfloCredentialBrokerClient] credential resolution failed",
+                extra={
+                    "status_code": response.status_code,
+                    "tenant_id": tenant_id,
+                    "source_system": source_system,
+                },
+            )
+            raise ValueError(
+                f"Peakflo credential broker returned {response.status_code}: {response.text}"
+            )
+
+        return response.json()
+

--- a/src/servers/peakflo/credential_broker.py
+++ b/src/servers/peakflo/credential_broker.py
@@ -81,4 +81,3 @@ class PeakfloCredentialBrokerClient:
             )
 
         return response.json()
-

--- a/src/servers/peakflo/main.py
+++ b/src/servers/peakflo/main.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode
 from pathlib import Path
 
 from servers.peakflo.factories.peakflo_api_factory import PeakfloApiToolFactory
+from servers.peakflo.credential_broker import PeakfloCredentialBrokerClient
 
 # Add project root and src directory to Python path
 project_root = os.path.abspath(
@@ -107,6 +108,23 @@ async def get_peakflo_credentials(user_id, api_key=None):
         return token
 
     raise ValueError(f"Peakflo token not found for user {user_id}.")
+
+
+async def get_system_of_record_credentials(
+    tenant_id: str, source_system: str, purpose: str = "workflow"
+):
+    """
+    Resolve credentials for a Peakflo-connected system of record.
+
+    This is for internal tool implementations that call Xero/NetSuite/etc.
+    directly. Do not return this value from an MCP tool.
+    """
+    broker = PeakfloCredentialBrokerClient()
+    return await broker.resolve_system_of_record_credentials(
+        tenant_id=tenant_id,
+        source_system=source_system,
+        purpose=purpose,
+    )
 
 
 async def make_peakflo_request(name, arguments, token):


### PR DESCRIPTION
## Summary
- add PeakfloCredentialBrokerClient for pfMCP service-to-service credential resolution
- add get_system_of_record_credentials helper for direct provider tools
- document PEAKFLO_INTERNAL_API_BASE_URL and PF_MCP_CREDENTIAL_BROKER_SECRET env vars

## Validation
- python AST syntax check passed for changed pfMCP files