### PR TITLE
feat(peakflo): list_whatsapp_templates tool + WA template fields on send_message

### DIFF
--- a/src/servers/peakflo/README.md
+++ b/src/servers/peakflo/README.md
@@ -37,6 +37,7 @@ python src/servers/peakflo/main.py auth
 | **delete_collection_workflow** | Delete a workflow template and every action under it. Customers assigned to this workflow stop receiving its cadence. Routes through `DELETE /v1/collection-workflows/:externalId`. |
 | **get_collection_workflow_action** | Read one step of a workflow. The parent `get_collection_workflow` already returns nested actions; use this when you already know the `actionExternalId` (e.g. to verify a PATCH landed). Routes through `GET /v1/collection-workflows/:externalId/actions/:actionExternalId`. |
 | **delete_collection_workflow_action** | Delete one step from a workflow's cadence. The rest keeps firing. Routes through `DELETE /v1/collection-workflows/:externalId/actions/:actionExternalId`. |
+| **list_whatsapp_templates** | List Meta-approved WhatsApp templates registered for the tenant. Call this before dispatching a WhatsApp message via `send_message` — the WhatsApp Business API rejects free-form text outside a 24h reply window, so every cold outreach must reference an approved template. Returns an empty list if the tenant has none configured. Routes through `GET /v1/whatsapp-templates`. |
 
 ### Run
 

--- a/src/servers/peakflo/config.yaml
+++ b/src/servers/peakflo/config.yaml
@@ -64,3 +64,6 @@ tools:
   - name: "delete_collection_workflow_action"
     description: "Delete one step (action) from a collection workflow"
     required_scopes: []
+  - name: "list_whatsapp_templates"
+    description: "List Meta-approved WhatsApp templates for the tenant (needed before send_message on the whatsapp channel)"
+    required_scopes: []

--- a/src/servers/peakflo/main.py
+++ b/src/servers/peakflo/main.py
@@ -405,6 +405,10 @@ async def make_peakflo_request(name, arguments, token):
         method = "GET"
         url = f"{PEAKFLO_V1_BASE_URL}/tenant"
         message = "Tenant information fetched successfully"
+    elif name == "list_whatsapp_templates":
+        method = "GET"
+        url = f"{PEAKFLO_V1_BASE_URL}/whatsapp-templates"
+        message = "WhatsApp templates listed successfully"
     else:
         raise ValueError(f"Unknown tool call: {name}")
 

--- a/src/servers/peakflo/schemas/utility.py
+++ b/src/servers/peakflo/schemas/utility.py
@@ -291,8 +291,54 @@ send_message_input_schema = {
             "type": "string",
             "description": "Optional display name shown in action logs / dashboards. Defaults to 'Ad-hoc <channel>' if omitted.",
         },
+        "messageTemplateId": {
+            "type": "string",
+            "description": (
+                "WhatsApp channel only, REQUIRED for channel='whatsapp'. "
+                "External ID of a Meta-approved WhatsApp template — fetch "
+                "the tenant's approved templates first via "
+                "list_whatsapp_templates, then pass the chosen template's "
+                "externalId here. WhatsApp Business API rejects free-form "
+                "text outside a 24h reply window, so cold outreach must "
+                "always reference an approved template. Rejected on "
+                "non-whatsapp channels."
+            ),
+        },
+        "messageTemplateText": {
+            "type": "string",
+            "description": (
+                "WhatsApp channel only. The template's raw text shape with "
+                "{{1}}, {{2}}, … placeholders — the same 'text' field "
+                "returned by list_whatsapp_templates. Optional; kept on the "
+                "action for downstream tracking."
+            ),
+        },
+        "variableValues": {
+            "type": "object",
+            "additionalProperties": True,
+            "description": (
+                "WhatsApp channel only. Slot-value map for the chosen "
+                "template's {{1}}, {{2}}, … placeholders. Keys mirror the "
+                "template's variableMapping (returned by "
+                "list_whatsapp_templates); values are the strings that fill "
+                "each slot. Optional but usually required by the template."
+            ),
+        },
     },
     "required": ["channel", "companyExternalId", "messageBody"],
+}
+
+
+# list_whatsapp_templates — list Meta-approved WhatsApp templates for the
+# authenticated tenant. Callers use this to build a template picker before
+# dispatching a WhatsApp send via send_message. WhatsApp Business API
+# rejects free-form text outside a 24h reply window, so a cold outreach must
+# always reference an approved template — this tool is the only way for an
+# agent to discover which template IDs are valid to pass as
+# send_message.messageTemplateId.
+list_whatsapp_templates_input_schema = {
+    "type": "object",
+    "properties": {},
 }
 
 

--- a/src/servers/peakflo/tools/peakflo_api.py
+++ b/src/servers/peakflo/tools/peakflo_api.py
@@ -14,6 +14,7 @@ from servers.peakflo.schemas.utility import (
     update_collection_workflow_action_input_schema,
     list_collection_workflows_input_schema,
     get_collection_workflow_input_schema,
+    list_whatsapp_templates_input_schema,
 )
 from servers.peakflo.schemas.invoice import (
     create_invoice_schema,
@@ -191,5 +192,20 @@ utility_tools = [
             "type": "object",
             "properties": {},
         },
+    ),
+    Tool(
+        name="list_whatsapp_templates",
+        description=(
+            "List Meta-approved WhatsApp templates registered for the "
+            "authenticated tenant. Call this before dispatching a WhatsApp "
+            "message via send_message — the WhatsApp Business API rejects "
+            "free-form text outside a 24h reply window, so every cold "
+            "outreach must reference an approved template. Pick a template "
+            "from the response and pass its externalId as "
+            "send_message.messageTemplateId. Returns an empty list if the "
+            "tenant has no approved templates configured — in that case, "
+            "route the send through email/SMS instead."
+        ),
+        inputSchema=list_whatsapp_templates_input_schema,
     ),
 ]


### PR DESCRIPTION
## Summary

Companion to [peakflo/api#684](https://github.com/peakflo/api/pull/684) which ships `GET /v1/whatsapp-templates` and extends `/v2/messages/send` with template fields.

WhatsApp Business API rejects free-form text outside a 24h reply window — every cold outreach must reference a Meta-approved template. `autoWhatsappMessageSender.utils.ts:368` in peakflo-web throws \`Whatsapp Action does not have a message template ID associated\` when the action is missing one. Agents need a way to discover valid template IDs before dispatching; this PR adds that discovery + plumbing.

## Changes

- **New tool: `list_whatsapp_templates`** — wraps `GET /v1/whatsapp-templates`. Returns tenant's Meta-approved templates so the agent can pick one before sending.
- **`send_message` schema extension** — adds `messageTemplateId`, `messageTemplateText`, `variableValues`. WhatsApp only; rejected on other channels by the peakflo-api Joi validator. Descriptions point the agent to `list_whatsapp_templates` so it knows how to discover valid IDs.

## Test plan

- [ ] Black passes (\`black src/servers/peakflo\`)
- [ ] Smoke test: \`list_whatsapp_templates\` on a stage tenant returns configured templates
- [ ] Smoke test: \`send_message channel=whatsapp\` without \`messageTemplateId\` returns 400 with helpful message
- [ ] Smoke test: \`send_message channel=whatsapp\` with valid \`messageTemplateId\` succeeds
- [ ] Regression: \`send_message channel=email\` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)