### PR TITLE
feat(peakflo): assign_customer_to_workflow tool

### DIFF
--- a/src/servers/peakflo/README.md
+++ b/src/servers/peakflo/README.md
@@ -38,6 +38,7 @@ python src/servers/peakflo/main.py auth
 | **get_collection_workflow_action** | Read one step of a workflow. The parent `get_collection_workflow` already returns nested actions; use this when you already know the `actionExternalId` (e.g. to verify a PATCH landed). Routes through `GET /v1/collection-workflows/:externalId/actions/:actionExternalId`. |
 | **delete_collection_workflow_action** | Delete one step from a workflow's cadence. The rest keeps firing. Routes through `DELETE /v1/collection-workflows/:externalId/actions/:actionExternalId`. |
 | **list_whatsapp_templates** | List Meta-approved WhatsApp templates registered for the tenant. Call this before dispatching a WhatsApp message via `send_message` — the WhatsApp Business API rejects free-form text outside a 24h reply window, so every cold outreach must reference an approved template. Returns an empty list if the tenant has none configured. Routes through `GET /v1/whatsapp-templates`. |
+| **assign_customer_to_workflow** | Reassign a customer's default collection workflow to a specific template. Used to apply an AR Golden Workflow recommendation — e.g. "shift this Large-Doubtful account onto the call-led golden workflow." Discover valid `workflowExternalId` values via `list_collection_workflows`. Only affects NEW invoices for the customer; existing open invoices keep whatever workflow they were created with. Routes through `POST /v1/customers/:customerExternalId/assign-workflow`. |
 
 ### Run
 

--- a/src/servers/peakflo/config.yaml
+++ b/src/servers/peakflo/config.yaml
@@ -67,3 +67,6 @@ tools:
   - name: "list_whatsapp_templates"
     description: "List Meta-approved WhatsApp templates for the tenant (needed before send_message on the whatsapp channel)"
     required_scopes: []
+  - name: "assign_customer_to_workflow"
+    description: "Reassign a customer's default collection workflow to a specific template (AR Golden Workflow recommendations)"
+    required_scopes: []

--- a/src/servers/peakflo/main.py
+++ b/src/servers/peakflo/main.py
@@ -409,6 +409,14 @@ async def make_peakflo_request(name, arguments, token):
         method = "GET"
         url = f"{PEAKFLO_V1_BASE_URL}/whatsapp-templates"
         message = "WhatsApp templates listed successfully"
+    elif name == "assign_customer_to_workflow":
+        customer_external_id = arguments.pop("customerExternalId")
+        method = "POST"
+        url = (
+            f"{PEAKFLO_V1_BASE_URL}/customers/"
+            f"{customer_external_id}/assign-workflow"
+        )
+        message = "Customer workflow assigned successfully"
     else:
         raise ValueError(f"Unknown tool call: {name}")
 

--- a/src/servers/peakflo/schemas/utility.py
+++ b/src/servers/peakflo/schemas/utility.py
@@ -342,6 +342,40 @@ list_whatsapp_templates_input_schema = {
 }
 
 
+# assign_customer_to_workflow — point a customer's default collection
+# workflow at a specific template. Motivating flow: the AR Golden Workflow
+# Recommender emits "shift these N customers onto golden workflow Y"
+# recommendations based on where each customer sits in the 2×2
+# value×risk segment matrix; this tool is what applies one recommendation
+# per customer. Existing open invoices keep whatever workflow they were
+# created with — only NEW invoices for the customer start running through
+# the reassigned cadence. Bulk re-workflow of open invoices is a separate
+# future operation.
+assign_customer_to_workflow_input_schema = {
+    "type": "object",
+    "properties": {
+        "customerExternalId": {
+            "type": "string",
+            "description": (
+                "External (source) ID of the customer whose default "
+                "collection workflow will be reassigned. Same value shape "
+                "as send_message.companyExternalId."
+            ),
+        },
+        "workflowExternalId": {
+            "type": "string",
+            "description": (
+                "External ID of the collection workflow template to assign "
+                "as this customer's new default cadence. Must belong to the "
+                "authenticated tenant. Discover options via "
+                "list_collection_workflows."
+            ),
+        },
+    },
+    "required": ["customerExternalId", "workflowExternalId"],
+}
+
+
 # update_collection_workflow — partial update of a dunning cadence.
 # Backs PUT /v1/collection-workflows/:externalId. Agents use this to change
 # the cadence's sender, reply-to, or rename it. Action steps are edited via

--- a/src/servers/peakflo/tools/peakflo_api.py
+++ b/src/servers/peakflo/tools/peakflo_api.py
@@ -15,6 +15,7 @@ from servers.peakflo.schemas.utility import (
     list_collection_workflows_input_schema,
     get_collection_workflow_input_schema,
     list_whatsapp_templates_input_schema,
+    assign_customer_to_workflow_input_schema,
 )
 from servers.peakflo.schemas.invoice import (
     create_invoice_schema,
@@ -192,6 +193,19 @@ utility_tools = [
             "type": "object",
             "properties": {},
         },
+    ),
+    Tool(
+        name="assign_customer_to_workflow",
+        description=(
+            "Reassign a customer's default collection workflow (dunning "
+            "cadence) to a specific template. Used to apply an AR Golden "
+            "Workflow recommendation — e.g. 'shift this Large-Doubtful "
+            "account onto the call-led golden workflow'. Discover valid "
+            "workflowExternalIds via list_collection_workflows. "
+            "Only affects NEW invoices for the customer; existing open "
+            "invoices keep whatever workflow they were created with."
+        ),
+        inputSchema=assign_customer_to_workflow_input_schema,
     ),
     Tool(
         name="list_whatsapp_templates",


### PR DESCRIPTION
## Summary

Companion to [peakflo/api#685](https://github.com/peakflo/api/pull/685). Wraps \`POST /v1/customers/:externalId/assign-workflow\` so agents (and the AR Golden Workflow Recommender specifically) can apply "shift this customer onto workflow Y" recommendations without touching the full \`updateCustomer\` surface.

Tool description points to \`list_collection_workflows\` so an LLM knows how to discover valid workflow externalIds, and calls out that only NEW invoices for the reassigned customer pick up the new cadence — existing open invoices keep their prior workflow assignment.

## Test plan

- [x] Black passes
- [ ] Smoke test: \`assign_customer_to_workflow\` with valid IDs → 200
- [ ] Smoke test: with bogus workflowExternalId → 404
- [ ] Smoke test: with bogus customerExternalId → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)