### PR TITLE
feat(peakflo): expose NetSuite tools through Peakflo connections (like Xero)

### DIFF
--- a/src/servers/netsuite/README.md
+++ b/src/servers/netsuite/README.md
@@ -5,10 +5,44 @@ The NetSuite MCP Server provides seamless integration with NetSuite's REST API, 
 ## Features
 
 - **Record Management**: Create and update records of any type in NetSuite
-- **Vendor Search**: Search for vendors by email address or name
+- **Vendor Search**: Search for vendors by email address or name (via SuiteQL)
 - **SuiteQL Execution**: Run custom SuiteQL queries for advanced data retrieval
-- **Authentication**: Secure OAuth 1.0a authentication with NetSuite
+- **Authentication**: Token-Based Authentication (OAuth 1.0a / HMAC-SHA256) **or** OAuth 2.0 Bearer
 - **Error Handling**: Comprehensive error handling with retry logic
+
+## Endpoints & Authentication
+
+All tools call the **SuiteTalk REST Web Services** on
+`https://{account_id}.suitetalk.api.netsuite.com/services/rest` (the account id
+is lowercased and `_` → `-`, e.g. `1234567_SB1` → `1234567-sb1`):
+
+- Records: `POST /record/v1/{type}`, `PATCH /record/v1/{type}/{id}`
+- SuiteQL: `POST /query/v1/suiteql` (with `Prefer: transient`)
+
+The client selects its auth mode automatically from whichever credentials are
+present:
+
+| Mode | Credentials | Header |
+|------|-------------|--------|
+| Token-Based Auth (OAuth 1.0a) | `account_id` + `consumer_key`/`consumer_secret` + `token_id`/`token_secret` | `Authorization: OAuth ...` (HMAC-SHA256, realm = account id) |
+| OAuth 2.0 | `account_id` + `access_token` | `Authorization: Bearer {access_token}` |
+
+## Access via a Peakflo connection (shared credentials)
+
+Just like Xero, NetSuite tools are surfaced automatically through the **Peakflo
+MCP server** when a Peakflo tenant is connected to NetSuite (`sourceSystem =
+"netsuite"`). The Peakflo server:
+
+1. Resolves the tenant's `sourceSystem` via `GET /v1/tenant`.
+2. If it is `netsuite`, lists the NetSuite tools prefixed with `netsuite__`
+   (e.g. `netsuite__execute_suiteql`).
+3. On a `netsuite__*` call, resolves short-lived NetSuite credentials from the
+   Peakflo credential broker (`POST /internal/credentials/system-of-record/resolve`
+   with `sourceSystem: "netsuite"`) and injects them into this server via a
+   `credential_resolver` — so agents never see the raw credentials.
+
+No env-var setup is needed for this path; Peakflo owns credential storage and
+refresh. The env-var setup below is only for running this server standalone.
 
 ## Prerequisites
 

--- a/src/servers/netsuite/main.py
+++ b/src/servers/netsuite/main.py
@@ -7,6 +7,8 @@ from typing import Dict, Any, Optional
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+from requests_oauthlib import OAuth1
+from oauthlib.oauth1 import SIGNATURE_HMAC_SHA256, SIGNATURE_TYPE_AUTH_HEADER
 
 project_root = os.path.abspath(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
@@ -28,23 +30,46 @@ logger = logging.getLogger(SERVICE_NAME)
 
 
 class NetSuiteClient:
-    """NetSuite REST API client"""
+    """
+    NetSuite SuiteTalk REST API client.
+
+    Supports the two authentication modes NetSuite exposes for REST:
+
+    * Token-Based Authentication (OAuth 1.0a / TBA) — the default for
+      integrations. Requires account_id + consumer_key/secret + token_id/secret
+      and signs each request with HMAC-SHA256.
+    * OAuth 2.0 Bearer — when Peakflo holds a short-lived OAuth 2.0 access token
+      for the tenant's NetSuite connection. Requires account_id + access_token.
+
+    The auth mode is selected automatically from whichever credentials are
+    present, so the same client works for both the env-var (TBA) path and the
+    Peakflo credential-broker path.
+    """
 
     def __init__(
         self,
         account_id: str,
-        consumer_key: str,
-        consumer_secret: str,
-        token_id: str,
-        token_secret: str,
+        consumer_key: Optional[str] = None,
+        consumer_secret: Optional[str] = None,
+        token_id: Optional[str] = None,
+        token_secret: Optional[str] = None,
+        access_token: Optional[str] = None,
     ):
+        if not account_id:
+            raise ValueError("NetSuite account_id is required")
+
         self.account_id = account_id
         self.consumer_key = consumer_key
         self.consumer_secret = consumer_secret
         self.token_id = token_id
         self.token_secret = token_secret
+        self.access_token = access_token
+
+        # The SuiteTalk REST host uses the account id lowercased with '_' -> '-'
+        # (e.g. account "1234567_SB1" -> host "1234567-sb1.suitetalk...").
+        host_account = account_id.lower().replace("_", "-")
         self.base_url = (
-            f"https://{account_id}.restlets.api.netsuite.com/rest/platform/v1"
+            f"https://{host_account}.suitetalk.api.netsuite.com/services/rest"
         )
 
         # Set up retry strategy
@@ -58,98 +83,116 @@ class NetSuiteClient:
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
 
-    def _get_headers(self) -> Dict[str, str]:
-        """Get authentication headers for NetSuite API"""
-        # Note: This is a simplified implementation
-        # In production, you'd want to implement proper OAuth 1.0a signature
-        return {
+    def _auth(self) -> Optional[OAuth1]:
+        """
+        Build the OAuth 1.0a (TBA) request signer, or None when using OAuth 2.0.
+        """
+        if self.access_token:
+            return None
+        if all(
+            [self.consumer_key, self.consumer_secret, self.token_id, self.token_secret]
+        ):
+            return OAuth1(
+                client_key=self.consumer_key,
+                client_secret=self.consumer_secret,
+                resource_owner_key=self.token_id,
+                resource_owner_secret=self.token_secret,
+                signature_method=SIGNATURE_HMAC_SHA256,
+                signature_type=SIGNATURE_TYPE_AUTH_HEADER,
+                # NetSuite requires the account id (canonical upper form) as the
+                # OAuth realm.
+                realm=self.account_id.upper(),
+            )
+        raise ValueError(
+            "NetSuite credentials are incomplete: provide an OAuth 2.0 access_token "
+            "or the full TBA set (consumer_key, consumer_secret, token_id, token_secret)."
+        )
+
+    def _headers(self, extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.consumer_key}",
-            "X-NetSuite-Account": self.account_id,
+            "Accept": "application/json",
         }
+        if self.access_token:
+            headers["Authorization"] = f"Bearer {self.access_token}"
+        if extra:
+            headers.update(extra)
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Optional[Dict[str, Any]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        try:
+            response = self.session.request(
+                method,
+                url,
+                json=json_body,
+                headers=self._headers(extra_headers),
+                auth=self._auth(),
+                timeout=60,
+            )
+            response.raise_for_status()
+            if response.content:
+                try:
+                    return response.json()
+                except ValueError:
+                    return {"raw": response.text}
+            return {}
+        except requests.exceptions.RequestException as e:
+            detail = ""
+            if getattr(e, "response", None) is not None:
+                detail = e.response.text
+            logger.error(f"NetSuite {method} {path} failed: {e} {detail}")
+            raise Exception(f"NetSuite {method} {path} failed: {e} {detail}")
 
     def create_record(self, record_type: str, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Create a new record in NetSuite"""
-        url = f"{self.base_url}/record/{record_type}"
-        headers = self._get_headers()
-
-        try:
-            response = self.session.post(url, json=data, headers=headers)
-            response.raise_for_status()
-            return response.json()
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Error creating {record_type} record: {e}")
-            raise Exception(f"Failed to create {record_type} record: {str(e)}")
+        """Create a new record in NetSuite via the SuiteTalk REST record API."""
+        return self._request("POST", f"/record/v1/{record_type}", json_body=data)
 
     def update_record(
         self, record_type: str, record_id: str, data: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Update an existing record in NetSuite"""
-        url = f"{self.base_url}/record/{record_type}/{record_id}"
-        headers = self._get_headers()
+        """Update an existing record in NetSuite via the SuiteTalk REST record API."""
+        return self._request(
+            "PATCH", f"/record/v1/{record_type}/{record_id}", json_body=data
+        )
 
-        try:
-            response = self.session.patch(url, json=data, headers=headers)
-            response.raise_for_status()
-            return response.json()
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Error updating {record_type} record {record_id}: {e}")
-            raise Exception(
-                f"Failed to update {record_type} record {record_id}: {str(e)}"
-            )
+    def execute_suiteql(
+        self, query: str, limit: int = 1000, offset: int = 0
+    ) -> Dict[str, Any]:
+        """Execute a SuiteQL query via the SuiteTalk REST query API."""
+        path = f"/query/v1/suiteql?limit={limit}&offset={offset}"
+        # SuiteQL requires the "Prefer: transient" header.
+        return self._request(
+            "POST",
+            path,
+            json_body={"q": query},
+            extra_headers={"Prefer": "transient"},
+        )
 
     def search_vendor_by_email(self, email: str) -> Dict[str, Any]:
-        """Search for a vendor by email address"""
-        url = f"{self.base_url}/search"
-        headers = self._get_headers()
-
-        search_query = {
-            "type": "vendor",
-            "filters": [{"field": "email", "operator": "is", "value": email}],
-        }
-
-        try:
-            response = self.session.post(url, json=search_query, headers=headers)
-            response.raise_for_status()
-            return response.json()
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Error searching vendor by email {email}: {e}")
-            raise Exception(f"Failed to search vendor by email {email}: {str(e)}")
+        """Search for a vendor by email address (implemented via SuiteQL)."""
+        safe = email.replace("'", "''")
+        query = (
+            "SELECT id, entityid, companyname, email FROM vendor "
+            f"WHERE email = '{safe}' AND isinactive = 'F'"
+        )
+        return self.execute_suiteql(query)
 
     def search_vendor_by_name(self, vendor_name: str) -> Dict[str, Any]:
-        """Search for a vendor by name"""
-        url = f"{self.base_url}/search"
-        headers = self._get_headers()
-
-        search_query = {
-            "type": "vendor",
-            "filters": [
-                {"field": "entityid", "operator": "contains", "value": vendor_name}
-            ],
-        }
-
-        try:
-            response = self.session.post(url, json=search_query, headers=headers)
-            response.raise_for_status()
-            return response.json()
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Error searching vendor by name {vendor_name}: {e}")
-            raise Exception(f"Failed to search vendor by name {vendor_name}: {str(e)}")
-
-    def execute_suiteql(self, query: str) -> Dict[str, Any]:
-        """Execute a SuiteQL query"""
-        url = f"{self.base_url}/query"
-        headers = self._get_headers()
-
-        query_data = {"q": query}
-
-        try:
-            response = self.session.post(url, json=query_data, headers=headers)
-            response.raise_for_status()
-            return response.json()
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Error executing SuiteQL query: {e}")
-            raise Exception(f"Failed to execute SuiteQL query: {str(e)}")
+        """Search for a vendor by name, partial match (implemented via SuiteQL)."""
+        safe = vendor_name.replace("'", "''")
+        query = (
+            "SELECT id, entityid, companyname, email FROM vendor "
+            f"WHERE UPPER(entityid) LIKE UPPER('%{safe}%') AND isinactive = 'F'"
+        )
+        return self.execute_suiteql(query)
 
 
 async def get_netsuite_credentials(
@@ -185,13 +228,20 @@ async def get_netsuite_credentials(
     return credentials
 
 
-def create_server(user_id: str, api_key: Optional[str] = None):
+def create_server(
+    user_id: str, api_key: Optional[str] = None, credential_resolver=None
+):
     """
     Initializes and configures a NetSuite MCP server instance.
 
     Args:
         user_id (str): The unique user identifier for session context.
         api_key (Optional[str]): Optional API key for user auth context.
+        credential_resolver: Optional async callable used by wrapper servers
+            (e.g. the Peakflo server) to resolve NetSuite credentials outside the
+            default env-var path. It receives (user_id, api_key) and must return a
+            dict of NetSuiteClient kwargs (account_id + TBA fields and/or
+            access_token). Defaults to get_netsuite_credentials.
 
     Returns:
         Server: Configured server instance with all NetSuite tools registered.
@@ -199,6 +249,7 @@ def create_server(user_id: str, api_key: Optional[str] = None):
     server = Server("netsuite-server")
     server.user_id = user_id
     server.api_key = api_key
+    server.credential_resolver = credential_resolver or get_netsuite_credentials
 
     @server.list_tools()
     async def handle_list_tools() -> list[types.Tool]:
@@ -310,8 +361,9 @@ def create_server(user_id: str, api_key: Optional[str] = None):
             raise ValueError("Missing arguments")
 
         try:
-            # Get NetSuite credentials
-            credentials = await get_netsuite_credentials(user_id, api_key)
+            # Get NetSuite credentials (env-var default, or broker-resolved when
+            # invoked through the Peakflo server via credential_resolver).
+            credentials = await server.credential_resolver(user_id, api_key)
             netsuite_client = NetSuiteClient(**credentials)
 
             if name == "create_record":

--- a/src/servers/peakflo/main.py
+++ b/src/servers/peakflo/main.py
@@ -30,6 +30,7 @@ from mcp.server.models import InitializationOptions
 
 from src.auth.factory import create_auth_client
 from src.servers.xero import main as xero_main
+from src.servers.netsuite import main as netsuite_main
 
 SERVICE_NAME = Path(__file__).parent.name
 PEAKFLO_V1_BASE_URL = os.environ.get("PEAKFLO_API_BASE_URL")
@@ -45,7 +46,9 @@ logging.basicConfig(
 logger = logging.getLogger(SERVICE_NAME)
 
 SOURCE_SYSTEM_XERO = "xero"
+SOURCE_SYSTEM_NETSUITE = "netsuite"
 XERO_TOOL_PREFIX = "xero__"
+NETSUITE_TOOL_PREFIX = "netsuite__"
 
 
 def authenticate_and_save_peakflo_key(user_id):
@@ -167,60 +170,45 @@ async def _resolve_peakflo_tenant_context(token: str) -> dict:
     return _nested_data(response)
 
 
-async def _should_expose_xero_tools(token: str) -> bool:
+async def _resolve_source_system(token: str) -> str:
+    """Return the lowercased sourceSystem the Peakflo tenant is connected to."""
     tenant_context = await _resolve_peakflo_tenant_context(token)
-    return str(tenant_context.get("sourceSystem", "")).lower() == SOURCE_SYSTEM_XERO
+    return str(tenant_context.get("sourceSystem", "")).lower()
 
 
-async def _get_prefixed_xero_tools() -> list[Tool]:
-    xero_server = xero_main.create_server("tool-discovery")
-    list_handler = xero_server.request_handlers[ListToolsRequest]
-    result = await list_handler(ListToolsRequest(method="tools/list"))
-    return [
-        _copy_tool(
-            tool,
-            name=f"{XERO_TOOL_PREFIX}{tool.name}",
-            description=f"[Xero] {tool.description or tool.name}",
-        )
-        for tool in result.root.tools
-    ]
+def _pick_credential(*sources: dict):
+    """Return the first non-empty value found across the given key sequences.
+
+    Called as _pick_credential(container, "keyA", "keyB", ...) — the first
+    positional is the dict, the rest are candidate keys.
+    """
+    container, *keys = sources
+    for key in keys:
+        value = container.get(key)
+        if value:
+            return value
+    return None
 
 
-async def _call_xero_tool_via_peakflo_connection(
-    server: Server,
-    token: str,
-    name: str,
-    arguments: dict | None,
-):
-    tenant_context = await _resolve_peakflo_tenant_context(token)
-    tenant_id = tenant_context.get("tenantId")
-    source_system = str(tenant_context.get("sourceSystem", "")).lower()
-    if not tenant_id or source_system != SOURCE_SYSTEM_XERO:
-        return [
-            TextContent(
-                type="text",
-                text="Xero tools are only available for Peakflo tenants connected to Xero.",
-            )
-        ]
+def _build_xero_credential_resolver(tenant_id: str, tool_name: str):
+    """Return an async resolver yielding (access_token, xero_tenant_id) for Xero."""
 
-    xero_tool_name = name[len(XERO_TOOL_PREFIX) :]
-
-    async def broker_xero_credentials(user_id: str, api_key: str = None) -> tuple:
+    async def resolver(user_id: str = None, api_key: str = None) -> tuple:
         credentials = await get_system_of_record_credentials(
             tenant_id=tenant_id,
             source_system=SOURCE_SYSTEM_XERO,
-            purpose=f"pfmcp:{xero_tool_name}",
+            purpose=f"pfmcp:{tool_name}",
         )
-        credential_body = credentials.get("credentials") or {}
+        body = credentials.get("credentials") or {}
         access_token = (
             credentials.get("accessToken")
-            or credential_body.get("access_token")
-            or credential_body.get("accessToken")
+            or body.get("access_token")
+            or body.get("accessToken")
         )
         xero_tenant_id = (
             credentials.get("providerTenantId")
-            or credential_body.get("tenantId")
-            or credential_body.get("xeroTenantId")
+            or body.get("tenantId")
+            or body.get("xeroTenantId")
         )
         if not access_token or not xero_tenant_id:
             raise ValueError(
@@ -228,17 +216,143 @@ async def _call_xero_tool_via_peakflo_connection(
             )
         return access_token, xero_tenant_id
 
-    xero_server = xero_main.create_server(
+    return resolver
+
+
+def _build_netsuite_credential_resolver(tenant_id: str, tool_name: str):
+    """Return an async resolver yielding NetSuiteClient kwargs.
+
+    Supports both auth shapes Peakflo may hold for a NetSuite connection:
+      * OAuth 2.0 — accountId + accessToken
+      * Token-Based Auth (OAuth 1.0a) — accountId + consumer/token key & secret
+    """
+
+    async def resolver(user_id: str = None, api_key: str = None) -> dict:
+        credentials = await get_system_of_record_credentials(
+            tenant_id=tenant_id,
+            source_system=SOURCE_SYSTEM_NETSUITE,
+            purpose=f"pfmcp:{tool_name}",
+        )
+        body = credentials.get("credentials") or {}
+
+        def pick(*keys):
+            return _pick_credential(credentials, *keys) or _pick_credential(body, *keys)
+
+        account_id = pick(
+            "accountId", "account_id", "providerAccountId", "realm", "providerTenantId"
+        )
+        access_token = pick("accessToken", "access_token")
+        consumer_key = pick("consumerKey", "consumer_key")
+        consumer_secret = pick("consumerSecret", "consumer_secret")
+        token_id = pick("tokenId", "token_id", "tokenKey", "token_key")
+        token_secret = pick("tokenSecret", "token_secret")
+
+        if not account_id:
+            raise ValueError("Peakflo NetSuite connection is missing accountId")
+
+        has_tba = all([consumer_key, consumer_secret, token_id, token_secret])
+        if not access_token and not has_tba:
+            raise ValueError(
+                "Peakflo NetSuite connection is missing an OAuth 2.0 access_token "
+                "or the full Token-Based Auth credential set"
+            )
+
+        return {
+            "account_id": account_id,
+            "access_token": access_token,
+            "consumer_key": consumer_key,
+            "consumer_secret": consumer_secret,
+            "token_id": token_id,
+            "token_secret": token_secret,
+        }
+
+    return resolver
+
+
+# Registry of Peakflo-connected systems of record whose native provider tools we
+# surface through the Peakflo MCP server when the tenant is connected to them.
+# Adding an accounting/ERP source here is all it takes to expose its tools.
+SOURCE_SYSTEM_INTEGRATIONS = {
+    SOURCE_SYSTEM_XERO: {
+        "module": xero_main,
+        "prefix": XERO_TOOL_PREFIX,
+        "label": "Xero",
+        "resolver_builder": _build_xero_credential_resolver,
+    },
+    SOURCE_SYSTEM_NETSUITE: {
+        "module": netsuite_main,
+        "prefix": NETSUITE_TOOL_PREFIX,
+        "label": "NetSuite",
+        "resolver_builder": _build_netsuite_credential_resolver,
+    },
+}
+
+
+async def _get_prefixed_source_system_tools(source_system: str) -> list[Tool]:
+    """List the provider's tools, prefixed/labelled, for the connected source system."""
+    integration = SOURCE_SYSTEM_INTEGRATIONS.get(source_system)
+    if not integration:
+        return []
+    inner_server = integration["module"].create_server("tool-discovery")
+    list_handler = inner_server.request_handlers[ListToolsRequest]
+    result = await list_handler(ListToolsRequest(method="tools/list"))
+    prefix = integration["prefix"]
+    label = integration["label"]
+    return [
+        _copy_tool(
+            tool,
+            name=f"{prefix}{tool.name}",
+            description=f"[{label}] {tool.description or tool.name}",
+        )
+        for tool in result.root.tools
+    ]
+
+
+def _match_source_system_tool(name: str):
+    """Return (source_system, integration) for a prefixed tool name, else (None, None)."""
+    for source_system, integration in SOURCE_SYSTEM_INTEGRATIONS.items():
+        if name.startswith(integration["prefix"]):
+            return source_system, integration
+    return None, None
+
+
+async def _call_source_system_tool_via_peakflo_connection(
+    server: Server,
+    token: str,
+    source_system: str,
+    integration: dict,
+    name: str,
+    arguments: dict | None,
+):
+    tenant_context = await _resolve_peakflo_tenant_context(token)
+    tenant_id = tenant_context.get("tenantId")
+    tenant_source_system = str(tenant_context.get("sourceSystem", "")).lower()
+    label = integration["label"]
+    if not tenant_id or tenant_source_system != source_system:
+        return [
+            TextContent(
+                type="text",
+                text=(
+                    f"{label} tools are only available for Peakflo tenants "
+                    f"connected to {label}."
+                ),
+            )
+        ]
+
+    inner_tool_name = name[len(integration["prefix"]) :]
+    credential_resolver = integration["resolver_builder"](tenant_id, inner_tool_name)
+
+    inner_server = integration["module"].create_server(
         server.user_id,
         api_key=server.api_key,
-        credential_resolver=broker_xero_credentials,
+        credential_resolver=credential_resolver,
     )
-    call_handler = xero_server.request_handlers[CallToolRequest]
+    call_handler = inner_server.request_handlers[CallToolRequest]
     result = await call_handler(
         CallToolRequest(
             method="tools/call",
             params=CallToolRequestParams(
-                name=xero_tool_name,
+                name=inner_tool_name,
                 arguments=arguments or {},
             ),
         )
@@ -480,8 +594,12 @@ def create_server(user_id, api_key=None):
     async def handle_list_tools() -> list[Tool]:
         try:
             token = await get_peakflo_credentials(server.user_id, server.api_key)
-            if await _should_expose_xero_tools(token):
-                return [*tools, *(await _get_prefixed_xero_tools())]
+            source_system = await _resolve_source_system(token)
+            if source_system in SOURCE_SYSTEM_INTEGRATIONS:
+                return [
+                    *tools,
+                    *(await _get_prefixed_source_system_tools(source_system)),
+                ]
         except Exception as e:
             logger.warning(f"[peakflo] unable to resolve source-system tools: {e}")
         return tools
@@ -490,16 +608,20 @@ def create_server(user_id, api_key=None):
     async def handle_call_tool(name: str, arguments: dict | None) -> list[TextContent]:
         token = await get_peakflo_credentials(server.user_id, server.api_key)
 
-        if name.startswith(XERO_TOOL_PREFIX):
+        source_system, integration = _match_source_system_tool(name)
+        if integration:
             try:
-                return await _call_xero_tool_via_peakflo_connection(
-                    server, token, name, arguments
+                return await _call_source_system_tool_via_peakflo_connection(
+                    server, token, source_system, integration, name, arguments
                 )
             except Exception as e:
                 return [
                     TextContent(
                         type="text",
-                        text=f"Unexpected error performing Xero request: {str(e)}",
+                        text=(
+                            f"Unexpected error performing "
+                            f"{integration['label']} request: {str(e)}"
+                        ),
                     )
                 ]
 

--- a/tests/servers/netsuite/test_auth.py
+++ b/tests/servers/netsuite/test_auth.py
@@ -1,0 +1,151 @@
+"""
+Network-free unit tests for NetSuite auth-mode selection and the Peakflo
+credential-sharing path (mirrors how Xero is exposed through Peakflo).
+"""
+
+import asyncio
+from unittest import mock
+
+import pytest
+import requests
+
+from src.servers.netsuite import main as ns
+
+
+# --------------------------------------------------------------------------- #
+# NetSuiteClient auth-mode selection
+# --------------------------------------------------------------------------- #
+def test_base_url_normalizes_account_id():
+    client = ns.NetSuiteClient(
+        account_id="1234567_SB1",
+        consumer_key="ck",
+        consumer_secret="cs",
+        token_id="ti",
+        token_secret="ts",
+    )
+    assert (
+        client.base_url
+        == "https://1234567-sb1.suitetalk.api.netsuite.com/services/rest"
+    )
+
+
+def test_tba_signs_request_with_realm():
+    client = ns.NetSuiteClient(
+        account_id="1234567_SB1",
+        consumer_key="ck",
+        consumer_secret="cs",
+        token_id="ti",
+        token_secret="ts",
+    )
+    # No bearer header in TBA mode.
+    assert "Authorization" not in client._headers()
+
+    prepared = requests.Request(
+        "POST",
+        f"{client.base_url}/query/v1/suiteql",
+        json={"q": "SELECT 1"},
+        auth=client._auth(),
+    ).prepare()
+    auth_header = prepared.headers["Authorization"]
+    if isinstance(auth_header, bytes):
+        auth_header = auth_header.decode()
+    assert auth_header.startswith('OAuth realm="1234567_SB1"')
+    assert "oauth_signature_method" in auth_header
+    assert "HMAC-SHA256" in auth_header
+
+
+def test_oauth2_bearer_mode():
+    client = ns.NetSuiteClient(account_id="1234567", access_token="tok123")
+    assert client._auth() is None
+    assert client._headers()["Authorization"] == "Bearer tok123"
+
+
+def test_incomplete_credentials_raise():
+    client = ns.NetSuiteClient(account_id="1234567", consumer_key="only_one")
+    with pytest.raises(ValueError):
+        client._auth()
+
+
+def test_account_id_required():
+    with pytest.raises(ValueError):
+        ns.NetSuiteClient(account_id="")
+
+
+def test_suiteql_escapes_single_quotes():
+    client = ns.NetSuiteClient(account_id="1234567", access_token="tok")
+    captured = {}
+
+    def fake_execute(query, limit=1000, offset=0):
+        captured["query"] = query
+        return {"items": []}
+
+    client.execute_suiteql = fake_execute  # type: ignore[assignment]
+    client.search_vendor_by_name("O'Brien")
+    assert "O''Brien" in captured["query"]
+
+
+# --------------------------------------------------------------------------- #
+# Peakflo credential-broker resolver (shared-access path)
+# --------------------------------------------------------------------------- #
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _patch_broker(pf, payload):
+    async def fake(tenant_id, source_system, purpose="workflow"):
+        assert source_system == pf.SOURCE_SYSTEM_NETSUITE
+        return payload
+
+    return mock.patch.object(pf, "get_system_of_record_credentials", fake)
+
+
+def test_netsuite_resolver_tba_shape():
+    from servers.peakflo import main as pf
+
+    payload = {
+        "credentials": {
+            "accountId": "1234567_SB1",
+            "consumerKey": "ck",
+            "consumerSecret": "cs",
+            "tokenId": "ti",
+            "tokenSecret": "ts",
+        }
+    }
+    with _patch_broker(pf, payload):
+        creds = _run(
+            pf._build_netsuite_credential_resolver("tenantA", "execute_suiteql")()
+        )
+    # Resolved kwargs must construct a working TBA client.
+    client = ns.NetSuiteClient(**creds)
+    assert client.access_token is None
+    assert client._auth().__class__.__name__ == "OAuth1"
+
+
+def test_netsuite_resolver_oauth2_shape():
+    from servers.peakflo import main as pf
+
+    payload = {"providerAccountId": "999", "accessToken": "atok"}
+    with _patch_broker(pf, payload):
+        creds = _run(
+            pf._build_netsuite_credential_resolver("tenantA", "create_record")()
+        )
+    client = ns.NetSuiteClient(**creds)
+    assert client._auth() is None
+    assert client._headers()["Authorization"] == "Bearer atok"
+
+
+def test_netsuite_resolver_missing_credentials_raise():
+    from servers.peakflo import main as pf
+
+    with _patch_broker(pf, {"credentials": {"accountId": "1"}}):
+        with pytest.raises(ValueError):
+            _run(pf._build_netsuite_credential_resolver("t", "x")())
+
+
+def test_source_system_registry_and_matching():
+    from servers.peakflo import main as pf
+
+    assert set(pf.SOURCE_SYSTEM_INTEGRATIONS) == {"xero", "netsuite"}
+    assert pf._match_source_system_tool("netsuite__execute_suiteql")[0] == "netsuite"
+    assert pf._match_source_system_tool("xero__list_accounts")[0] == "xero"
+    assert pf._match_source_system_tool("get_tenant")[0] is None

--- a/tests/servers/netsuite/tests.py
+++ b/tests/servers/netsuite/tests.py
@@ -1,0 +1,34 @@
+import pytest
+from tests.utils.test_tools import get_test_id, run_tool_test
+
+# Shared context dictionary at module level
+SHARED_CONTEXT = {}
+
+# Live integration tests. These exercise the NetSuite server against a real
+# connection (env-var TBA credentials or a Peakflo-brokered connection) and are
+# skipped by the harness when no connection is configured.
+TOOL_TESTS = [
+    {
+        "name": "execute_suiteql",
+        "args_template": "with query='SELECT id, entityid FROM vendor WHERE isinactive = \\'F\\' FETCH FIRST 1 ROWS ONLY'",
+        "expected_keywords": ["items"],
+        "description": "run a read-only SuiteQL query against NetSuite",
+    },
+    {
+        "name": "search_vendor_by_name",
+        "args_template": "with vendor_name='a'",
+        "expected_keywords": ["items"],
+        "description": "search vendors by partial name via SuiteQL",
+    },
+]
+
+
+@pytest.fixture(scope="module")
+def context():
+    return SHARED_CONTEXT
+
+
+@pytest.mark.parametrize("test_config", TOOL_TESTS, ids=get_test_id)
+@pytest.mark.asyncio
+async def test_netsuite_tool(client, context, test_config):
+    return await run_tool_test(client, context, test_config)


### PR DESCRIPTION
## What & why

When a Workflo agent connects to Peakflo via pfMCP and the Peakflo tenant is connected to an accounting/ERP system, pfMCP already exposes that system's native tools using Peakflo's stored tokens — but only for **Xero** (#170). This PR does the **same for NetSuite**.

When `sourceSystem == "netsuite"`, the Peakflo MCP server now:
1. Lists NetSuite tools prefixed with `netsuite__` (e.g. `netsuite__execute_suiteql`, `netsuite__create_record`).
2. On call, resolves short-lived NetSuite credentials from the Peakflo credential broker (`POST /internal/credentials/system-of-record/resolve`, `sourceSystem: "netsuite"`) and injects them into the NetSuite server via a `credential_resolver` — **agents never see the raw credentials**.

## Changes

**`src/servers/peakflo/main.py`** — generalized the Xero-only exposure into a source-system registry (`SOURCE_SYSTEM_INTEGRATIONS`) supporting both `xero` and `netsuite`:
- `_resolve_source_system`, `_get_prefixed_source_system_tools`, `_match_source_system_tool`, `_call_source_system_tool_via_peakflo_connection` (generic).
- `_build_xero_credential_resolver` / `_build_netsuite_credential_resolver`.
- `handle_list_tools` / `handle_call_tool` now dispatch via the registry. Adding a new source of record is now a single registry entry.

**`src/servers/netsuite/main.py`** — the client was a non-functional placeholder (`Bearer {consumer_key}`, wrong `restlets` base URL, a non-existent `/search` endpoint). Made it real so shared credentials actually authenticate:
- Real **OAuth 1.0a TBA** signing (HMAC-SHA256, account-id realm) using the already-vendored `requests-oauthlib`, with an automatic **OAuth 2.0 Bearer** fallback (auth mode chosen from whichever creds are present).
- Correct **SuiteTalk REST** base URL (`{account}.suitetalk.api.netsuite.com/services/rest`, account id lowercased + `_`→`-`); records via `/record/v1/*`, SuiteQL via `/query/v1/suiteql` with `Prefer: transient`.
- Vendor search reimplemented via SuiteQL (with quote escaping).
- Added a `credential_resolver` hook to `create_server` (mirrors Xero) so wrapper servers inject creds.

**Tests** — `tests/servers/netsuite/`: network-free unit tests for auth-mode selection + the broker resolver (10/10 passing), plus live `TOOL_TESTS` for the harness.

**README** — documents the SuiteTalk endpoints, the two auth modes, and the Peakflo shared-access path.

## Notes
- No workflow-builder change is required for tool exposure — like Xero, the tools flow through the Peakflo MCP server's dynamic `list_tools`.
- The credential broker is already source-system agnostic; the API side just needs to resolve NetSuite credentials for `sourceSystem: "netsuite"` (same contract as Xero).
- The NetSuite resolver accepts both broker credential shapes (TBA field set or OAuth2 `accessToken` + `accountId`) to be robust to how Peakflo stores the connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)