### PR TITLE
[TSK-16927] Prevent Firestore emulator flag usage

### DIFF
--- a/src/servers/firestore/README.md
+++ b/src/servers/firestore/README.md
@@ -10,7 +10,6 @@ This MCP server provides comprehensive integration with Google Cloud Firestore, 
 - **Update Documents**: Modify existing documents with partial updates
 - **List Collections**: Discover available collections in your Firestore database
 - **Complex Field Types**: Support for timestamps and document references
-- **Emulator Support**: Work with Firestore emulator for development and testing
 
 ## Authentication
 
@@ -39,7 +38,6 @@ Query a Firestore collection with filters, ordering, and limits.
 - `limit` (optional): Maximum number of documents to return (default: 10)
 - `select_fields` (optional): Comma-separated document field paths to return (e.g. `code,name,accountName,sourceData.code`). When set, only these fields are fetched from Firestore; each document still includes `_id` with the document id. Omit to return full documents.
 - `database` (optional): Database ID (defaults to "(default)")
-- `use_emulator` (optional): Use Firestore emulator (default: false)
 
 **Example:**
 ```json
@@ -83,7 +81,6 @@ Retrieve a single document by its path.
 **Parameters:**
 - `document_path` (required): Full path to the document (e.g., "users/user123")
 - `database` (optional): Database ID (defaults to "(default)")
-- `use_emulator` (optional): Use Firestore emulator (default: false)
 
 **Example:**
 ```json
@@ -101,7 +98,6 @@ Create a new document in a Firestore collection with support for complex field t
 - `document_data` (required): Document data with field names and values (cannot be empty)
 - `document_id` (optional): Custom document ID (auto-generated if not provided)
 - `database` (optional): Database ID (defaults to "(default)")
-- `use_emulator` (optional): Use Firestore emulator (default: false)
 
 **Example:**
 ```json
@@ -131,7 +127,6 @@ Update an existing document in Firestore with partial updates.
 - `document_path` (required): Full path to the document (e.g., "users/user123")
 - `document_data` (required): Document data to update (cannot be empty)
 - `database` (optional): Database ID (defaults to "(default)")
-- `use_emulator` (optional): Use Firestore emulator (default: false)
 
 **Example:**
 ```json
@@ -158,7 +153,6 @@ List all collections in the database.
 
 **Parameters:**
 - `database` (optional): Database ID (defaults to "(default)")
-- `use_emulator` (optional): Use Firestore emulator (default: false)
 
 ## Filter Operators
 
@@ -224,10 +218,6 @@ When creating or updating documents, use special syntax for complex field types:
   }
 }
 ```
-
-## Emulator Support
-
-To use the Firestore emulator, set `use_emulator: true` in your tool calls. Make sure the Firestore emulator is running on `localhost:8080`.
 
 ## Error Handling
 

--- a/src/servers/firestore/main.py
+++ b/src/servers/firestore/main.py
@@ -239,9 +239,7 @@ def process_document_data(data, client):
         return data
 
 
-async def create_firestore_client(
-    user_id, api_key=None, project_id=None, use_emulator=False
-):
+async def create_firestore_client(user_id, api_key=None, project_id=None):
     """Create a Firestore client"""
     try:
         # Get Google OAuth2 credentials
@@ -288,9 +286,6 @@ async def create_firestore_client(
                 logger.warning(
                     "No project_id found in metadata or Application Default Credentials"
                 )
-
-        if use_emulator:
-            os.environ["FIRESTORE_EMULATOR_HOST"] = "localhost:8080"
 
         # Create Firestore client with OAuth2 credentials
         client = firestore.Client(project=final_project_id, credentials=credentials)
@@ -490,11 +485,6 @@ def create_server(user_id, api_key=None):
                         "type": "string",
                         "description": "Optional comma-separated list of document field paths to return (e.g. 'code,name,accountName,sourceData.code'). When set, Firestore returns only these fields plus the document id as `_id`. Omit to return full documents.",
                     },
-                    "use_emulator": {
-                        "type": "boolean",
-                        "default": False,
-                        "description": "Target the Firestore emulator if true.",
-                    },
                     "required": ["collection_path"],
                 },
                 # outputSchema={
@@ -517,11 +507,6 @@ def create_server(user_id, api_key=None):
                             "type": "string",
                             "description": "Database id to use. Defaults to `(default)` if unspecified.",
                         },
-                        "use_emulator": {
-                            "type": "boolean",
-                            "default": False,
-                            "description": "Target the Firestore emulator if true.",
-                        },
                     },
                     "required": ["document_path"],
                 },
@@ -539,11 +524,6 @@ def create_server(user_id, api_key=None):
                         "database": {
                             "type": "string",
                             "description": "Database id to use. Defaults to `(default)` if unspecified.",
-                        },
-                        "use_emulator": {
-                            "type": "boolean",
-                            "default": False,
-                            "description": "Target the Firestore emulator if true.",
                         },
                     },
                 },
@@ -576,11 +556,6 @@ def create_server(user_id, api_key=None):
                             "type": "string",
                             "description": "Database id to use. Defaults to `(default)` if unspecified.",
                         },
-                        "use_emulator": {
-                            "type": "boolean",
-                            "default": False,
-                            "description": "Target the Firestore emulator if true.",
-                        },
                     },
                     "required": ["collection_path", "document_data"],
                 },
@@ -604,11 +579,6 @@ def create_server(user_id, api_key=None):
                             "type": "string",
                             "description": "Database id to use. Defaults to `(default)` if unspecified.",
                         },
-                        "use_emulator": {
-                            "type": "boolean",
-                            "default": False,
-                            "description": "Target the Firestore emulator if true.",
-                        },
                     },
                     "required": ["document_path", "document_data"],
                 },
@@ -624,13 +594,12 @@ def create_server(user_id, api_key=None):
         )
 
         arguments = arguments or {}
+        if "use_emulator" in arguments:
+            logger.warning("Ignoring unsupported Firestore argument: use_emulator")
+            arguments.pop("use_emulator", None)
 
         try:
-            client = await create_firestore_client(
-                server.user_id,
-                server.api_key,
-                use_emulator=arguments.get("use_emulator", False),
-            )
+            client = await create_firestore_client(server.user_id, server.api_key)
 
             if name == "query_collection":
                 collection_path = arguments.get("collection_path")


### PR DESCRIPTION
## Summary
- remove Firestore MCP use_emulator tool schema support
- stop mutating FIRESTORE_EMULATOR_HOST from tool arguments
- ignore legacy use_emulator arguments defensively

## Testing
- python -m py_compile src/servers/firestore/main.py
- git diff --check -- src/servers/firestore/main.py src/servers/firestore/README.md