### PR TITLE
Add read_purchase_order and update_purchase_order tools

### DIFF
--- a/src/servers/peakflo/factories/peakflo_api_factory.py
+++ b/src/servers/peakflo/factories/peakflo_api_factory.py
@@ -1,14 +1,19 @@
 from typing import List
 from mcp.types import Tool
 
-from peakflo.tools.peakflo_api import vendor_tools, invoice_tools, utility_tools
+from peakflo.tools.peakflo_api import (
+    vendor_tools,
+    invoice_tools,
+    purchase_order_tools,
+    utility_tools,
+)
 
 
 class PeakfloApiToolFactory:
 
     @staticmethod
     def get_all_tools() -> List[Tool]:
-        return [*vendor_tools, *invoice_tools, *utility_tools]
+        return [*vendor_tools, *invoice_tools, *purchase_order_tools, *utility_tools]
 
     @staticmethod
     def build_tool(tool_schema: dict) -> Tool:

--- a/src/servers/peakflo/main.py
+++ b/src/servers/peakflo/main.py
@@ -122,6 +122,14 @@ async def make_peakflo_request(name, arguments, token):
         method = "PUT"
         url = f"{PEAKFLO_V1_BASE_URL}/invoices/{invoice_external_id}/attachments"
         message = "Attachment added to invoice successfully"
+    elif name == "read_purchase_order":
+        method = "GET"
+        url = f"{PEAKFLO_V1_BASE_URL}/purchase-order/{arguments['externalId']}"
+        message = "Purchase order fetched successfully"
+    elif name == "update_purchase_order":
+        method = "PUT"
+        url = f"{PEAKFLO_V1_BASE_URL}/purchase-order/{arguments['externalId']}"
+        message = "Purchase order updated successfully"
     elif name == "raise_invoice_dispute":
         method = "POST"
         url = f"{PEAKFLO_V1_BASE_URL}/upload-dispute"
@@ -185,6 +193,22 @@ async def make_peakflo_request(name, arguments, token):
         }
 
 
+def _normalize_purchase_order_dates(data):
+    """Convert DD-MM-YYYY date fields returned by the API to ISO (YYYY-MM-DD)
+    so a read result can be passed directly back into update_purchase_order.
+    """
+    if not isinstance(data, dict):
+        return data
+    result = dict(data)
+    for key in ("issueDate", "dueDate", "receiptDate", "deliveryDate"):
+        value = result.get(key)
+        if isinstance(value, str):
+            parts = value.split("-")
+            if len(parts) == 3 and len(parts[2]) == 4:
+                result[key] = f"{parts[2]}-{parts[1]}-{parts[0]}"
+    return result
+
+
 def create_server(user_id, api_key=None):
     server = Server(f"{SERVICE_NAME}-server")
     server.user_id = user_id
@@ -192,6 +216,7 @@ def create_server(user_id, api_key=None):
 
     tools = PeakfloApiToolFactory.get_all_tools()
     tool_names = [tool.name for tool in tools]
+    tool_output_schemas = {tool.name: tool.outputSchema for tool in tools}
 
     @server.list_tools()
     async def handle_list_tools() -> list[Tool]:
@@ -217,7 +242,15 @@ def create_server(user_id, api_key=None):
                     )
                 ]
 
-            return [TextContent(type="text", text=json.dumps(response, indent=2))]
+            content = [TextContent(type="text", text=json.dumps(response, indent=2))]
+
+            if tool_output_schemas.get(name) is not None:
+                data = response.get("data")
+                if name == "read_purchase_order":
+                    data = _normalize_purchase_order_dates(data)
+                return content, data
+
+            return content
 
         except Exception as e:
             return [

--- a/src/servers/peakflo/schemas/purchase_order.py
+++ b/src/servers/peakflo/schemas/purchase_order.py
@@ -1,0 +1,433 @@
+po_custom_field_schema = {
+    "type": "object",
+    "properties": {
+        "customFieldNumber": {
+            "type": "string",
+            "description": "Custom field number can be seen in the peakflo web UI",
+        },
+        "name": {
+            "type": "string",
+            "description": "Custom field name",
+        },
+        "value": {
+            "description": "Custom field value. Can be string, number or array. Dates need to be sent in ISO 8601 date format",
+        },
+    },
+    "required": ["customFieldNumber", "value"],
+}
+
+
+po_custom_field_output_schema = {
+    "type": "object",
+    "description": "Custom field as returned by the API on reads (no customFieldNumber echoed back)",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Custom field name",
+        },
+        "value": {
+            "description": "Custom field value",
+        },
+    },
+}
+
+
+po_item_schema = {
+    "type": "object",
+    "properties": {
+        "itemId": {
+            "type": "string",
+            "description": "ID of the item",
+        },
+        "sourceId": {
+            "type": "string",
+            "description": "Unique identifier of line item, used in 3 Way Matching. For a given object there should be no 2 line items with same sourceId.",
+        },
+        "name": {
+            "type": "string",
+            "description": "Name of the item",
+        },
+        "unit": {
+            "type": "string",
+            "description": "Unit of measurement",
+        },
+        "description": {
+            "type": "string",
+            "description": "Description of the item",
+        },
+        "quantity": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Quantity of the item, must be a positive number (fractional quantities allowed)",
+        },
+        "unitPrice": {
+            "type": "number",
+            "description": "Price per unit of the item",
+        },
+        "accountId": {
+            "type": "string",
+            "description": "ID of the account associated with the item",
+        },
+        "currency": {
+            "type": "string",
+            "description": "Currency of the item",
+        },
+        "type": {
+            "type": "string",
+            "description": "Type of the item",
+            "enum": [
+                "None",
+                "Product",
+                "Service",
+                "Hour",
+                "Day",
+                "Month",
+                "Year",
+                "Expense",
+                "Shipping",
+            ],
+        },
+        "wht": {
+            "type": "object",
+            "description": "Withholding tax details for the item",
+        },
+        "taxes": {
+            "type": "array",
+            "description": "Array of tax details for the item",
+            "items": {"type": "object"},
+        },
+        "discounts": {
+            "type": "array",
+            "description": "Array of discount details for the item",
+            "items": {"type": "object"},
+        },
+        "totalTax": {
+            "type": "number",
+            "description": "Total tax amount for the item",
+        },
+        "totalDiscount": {
+            "type": "number",
+            "description": "Total discount amount for the item",
+        },
+        "total": {
+            "type": "number",
+            "description": "Total amount for the item",
+        },
+        "customField": {
+            "type": "array",
+            "description": "Array of custom fields for the item",
+            "items": po_custom_field_schema,
+        },
+    },
+    "required": ["sourceId", "name", "quantity", "unitPrice"],
+}
+
+
+po_item_output_schema = {
+    "type": "object",
+    "properties": {
+        **{k: v for k, v in po_item_schema["properties"].items() if k != "customField"},
+        "itemId": {
+            "type": ["string", "null"],
+            "description": "ID of the item. Null when the line item has no external item ID.",
+        },
+        "quantity": {
+            "type": "number",
+            "description": "Quantity of the item",
+        },
+        "customFields": {
+            "type": "array",
+            "description": "Array of custom fields for the item",
+            "items": po_custom_field_output_schema,
+        },
+    },
+}
+
+
+po_attachment_schema = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Name of the attachment",
+        },
+        "dateCreated": {
+            "type": "string",
+            "description": "Timestamp of attachment creation",
+        },
+        "contentType": {
+            "type": "string",
+            "description": "MIME type of the attachment",
+        },
+        "fileSize": {
+            "type": "integer",
+            "description": "Size of the attachment in bytes",
+        },
+        "fileType": {
+            "type": "string",
+            "description": "Type of attachment",
+            "enum": [
+                "transaction",
+                "statement",
+                "cabinet",
+                "invoice",
+                "paymentProof",
+                "other",
+            ],
+        },
+        "signedUrl": {
+            "type": "string",
+            "description": "Signed url for the attachment",
+        },
+    },
+}
+
+
+read_purchase_order_output = {
+    "type": "object",
+    "properties": {
+        "externalId": {
+            "type": "string",
+            "description": "External ID of the purchase order",
+        },
+        "totalAmount": {
+            "type": "number",
+            "description": "Total amount of the purchase order",
+        },
+        "POAmount": {
+            "type": "number",
+            "description": "Amount related to the purchase order",
+        },
+        "totalWHT": {
+            "type": "number",
+            "description": "Total withholding tax amount",
+        },
+        "paidAmount": {
+            "type": "number",
+            "description": "Amount already paid",
+        },
+        "balanceAmount": {
+            "type": "number",
+            "description": "Remaining balance amount",
+        },
+        "currency": {
+            "type": "string",
+            "description": "Currency of the purchase order",
+        },
+        "issueDate": {
+            "type": "string",
+            "description": "Issue date of the purchase order (ISO8601 date format)",
+        },
+        "dueDate": {
+            "type": "string",
+            "description": "Due date of the purchase order (ISO8601 date format)",
+        },
+        "notes": {
+            "type": "string",
+            "description": "Notes related to the purchase order",
+        },
+        "deliveryInstructions": {
+            "type": "string",
+            "description": "Instructions for delivery",
+        },
+        "status": {
+            "type": "string",
+            "description": "Status of the purchase order",
+        },
+        "totalTax": {
+            "type": "number",
+            "description": "Total tax amount",
+        },
+        "fxRate": {
+            "type": "number",
+            "description": "Currency conversion rate",
+        },
+        "convertedAmount": {
+            "type": "number",
+            "description": "Converted amount in base currency",
+        },
+        "paymentTerms": {
+            "type": "number",
+            "description": "Payment terms in days",
+        },
+        "attachments": {
+            "type": "array",
+            "description": "List of attachments",
+            "items": po_attachment_schema,
+        },
+        "items": {
+            "type": "array",
+            "description": "List of items included in the purchase order",
+            "items": po_item_output_schema,
+        },
+        "PONumber": {
+            "type": "string",
+            "description": "Purchase order number",
+        },
+        "PQNumber": {
+            "type": "string",
+            "description": "Purchase quote number",
+        },
+        "updatedAt": {
+            "type": "string",
+            "description": "Date when the purchase order was last updated (ISO8601 format)",
+        },
+        "vendorId": {
+            "type": "string",
+            "description": "ID of the vendor associated with the purchase order",
+        },
+        "receiptDate": {
+            "type": "string",
+            "description": "Date of purchase order receipt (ISO8601 format)",
+        },
+        "deliveryDate": {
+            "type": "string",
+            "description": "Date of expected delivery (ISO8601 format)",
+        },
+        "bills": {
+            "type": "array",
+            "description": "List of associated bill IDs",
+            "items": {"type": "string"},
+        },
+        "receiptNotes": {
+            "type": "array",
+            "description": "Notes related to the receipt",
+            "items": {"type": "string"},
+        },
+        "balanceQuantity": {
+            "type": "number",
+            "description": "Remaining quantity balance",
+        },
+        "customFields": {
+            "type": "array",
+            "description": "Array of custom fields",
+            "items": po_custom_field_output_schema,
+        },
+        "subsidiaryReference": {
+            "type": ["string", "null"],
+            "description": "Subsidiary reference. Null when unassigned.",
+        },
+    },
+}
+
+
+update_purchase_order_schema = {
+    "type": "object",
+    "properties": {
+        "externalId": {
+            "type": "string",
+            "description": "External ID of the purchase order to update",
+        },
+        "tenantId": {
+            "type": "string",
+            "description": "Tenant ID",
+        },
+        "totalAmount": {
+            "type": "number",
+            "description": "Total amount of the purchase order",
+        },
+        "POAmount": {
+            "type": "number",
+            "description": "Amount related to the purchase order",
+        },
+        "totalWHT": {
+            "type": "number",
+            "description": "Total withholding tax amount",
+        },
+        "currency": {
+            "type": "string",
+            "description": "Currency of the purchase order",
+        },
+        "issueDate": {
+            "type": "string",
+            "description": "Issue date of the purchase order (ISO8601 date format)",
+        },
+        "requestedBy": {
+            "type": "string",
+            "description": "Person who requested the purchase order",
+        },
+        "dueDate": {
+            "type": "string",
+            "description": "Due date of the purchase order (ISO8601 date format)",
+        },
+        "notes": {
+            "type": "string",
+            "description": "Notes related to the purchase order",
+        },
+        "deliveryInstructions": {
+            "type": "string",
+            "description": "Instructions for delivery",
+        },
+        "status": {
+            "type": "string",
+            "description": "Status of the purchase order",
+        },
+        "totalTax": {
+            "type": "number",
+            "description": "Total tax amount",
+        },
+        "fxRate": {
+            "type": "number",
+            "description": "Currency conversion rate",
+        },
+        "convertedAmount": {
+            "type": "number",
+            "description": "Converted amount in base currency",
+        },
+        "paymentTerms": {
+            "type": "number",
+            "description": "Payment terms in days",
+        },
+        "items": {
+            "type": "array",
+            "description": "List of items included in the purchase order",
+            "items": po_item_schema,
+        },
+        "PONumber": {
+            "type": "string",
+            "description": "Purchase order number",
+        },
+        "PQNumber": {
+            "type": "string",
+            "description": "Purchase quote number",
+        },
+        "updatedAt": {
+            "type": "string",
+            "description": "Date when the purchase order was last updated (ISO8601 format)",
+        },
+        "vendorId": {
+            "type": "string",
+            "description": "ID of the vendor associated with the purchase order",
+        },
+        "receiptDate": {
+            "type": "string",
+            "description": "Date of purchase order receipt (ISO8601 format)",
+        },
+        "deliveryDate": {
+            "type": "string",
+            "description": "Date of expected delivery (ISO8601 format)",
+        },
+        "customField": {
+            "type": "array",
+            "description": "Array of custom fields",
+            "items": po_custom_field_schema,
+        },
+        "subsidiaryReference": {
+            "type": "string",
+            "description": "Subsidiary reference",
+        },
+    },
+    "required": [
+        "externalId",
+        "tenantId",
+        "POAmount",
+        "currency",
+        "issueDate",
+        "dueDate",
+        "status",
+        "items",
+        "PONumber",
+        "vendorId",
+    ],
+    "additionalProperties": false,
+}

--- a/src/servers/peakflo/tools/peakflo_api.py
+++ b/src/servers/peakflo/tools/peakflo_api.py
@@ -12,6 +12,10 @@ from servers.peakflo.schemas.invoice import (
     raise_invoice_dispute_schema,
     add_invoice_attachment_schema,
 )
+from servers.peakflo.schemas.purchase_order import (
+    read_purchase_order_output,
+    update_purchase_order_schema,
+)
 
 vendor_tools = [
     Tool(
@@ -60,6 +64,34 @@ invoice_tools = [
         name="add_invoice_attachment",
         description="Add an attachment to an existing invoice. Accepts a signed file URL; the server downloads and base64-encodes it.",
         inputSchema=add_invoice_attachment_schema,
+    ),
+]
+
+
+purchase_order_tools = [
+    Tool(
+        name="read_purchase_order",
+        description="Fetch purchase order details by external ID from Peakflo API",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "externalId": {
+                    "type": "string",
+                    "description": "External ID of the purchase order to fetch",
+                },
+                "tenantId": {
+                    "type": "string",
+                    "description": "Tenant ID",
+                },
+            },
+            "required": ["externalId", "tenantId"],
+        },
+        outputSchema=read_purchase_order_output,
+    ),
+    Tool(
+        name="update_purchase_order",
+        description="Update an existing purchase order with comprehensive details including line items, amounts, dates, and custom fields",
+        inputSchema=update_purchase_order_schema,
     ),
 ]
 


### PR DESCRIPTION
## Summary
- Adds `read_purchase_order` (GET) and `update_purchase_order` (PUT) tools to the Peakflo MCP server, mirroring the existing `read_vendor`/`create_vendor` pattern.
- New `src/servers/peakflo/schemas/purchase_order.py` with schemas for PO items, attachments, and custom fields.
- Wired into `tools/peakflo_api.py`, `factories/peakflo_api_factory.py`, and request handling in `main.py` (`GET`/`PUT` against `/purchase-order/{externalId}`).

## Test plan
- [ ] Verify `read_purchase_order` against a real `externalId` and confirm output schema matches API response
- [ ] Verify `update_purchase_order` against a real `externalId` with a partial body update